### PR TITLE
Allows for RecordNotFound errors to be defined in the settings

### DIFF
--- a/app/controllers/knock/application_controller.rb
+++ b/app/controllers/knock/application_controller.rb
@@ -1,6 +1,6 @@
 module Knock
   class ApplicationController < ActionController::Base
-    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+    rescue_from Knock.record_not_found_error_class, with: :not_found
 
   private
 

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -10,7 +10,7 @@ module Knock
 
   private
     def authenticate!
-      raise ActiveRecord::RecordNotFound unless user.authenticate(auth_params[:password])
+      raise Knock.record_not_found_error_class unless user.authenticate(auth_params[:password])
     end
 
     def auth_token

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -35,17 +35,16 @@ Knock.setup do |config|
   ## Default:
   # config.current_user_from_token = -> (claims) { User.find claims['sub'] }
 
-  ## Record not found error class
+  ## Object Mapper
   ## --------------------------------------------
   ##
-  ## This is how you can tell Knock what error class to use for
-  ## record not found cases. By default, it assumes you have
-  ## ActiveRecord and will raise ActiveRecord::RecordNotFound.
-  ## If you are using Mongoid you can raise Mongoid::Errors::DocumentNotFound
+  ## This is how you can tell Knock what object relation mapper you
+  ## are currently using. It defaults to :active_record but can also
+  ## be set to `:mongoid`.
   ##
   ##
   ## Default:
-  # config.record_not_found_error_class = ActiveRecord::RecordNotFound
+  # config.object_mapper = :active_record
 
   ## Expiration claim
   ## ----------------

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -35,6 +35,17 @@ Knock.setup do |config|
   ## Default:
   # config.current_user_from_token = -> (claims) { User.find claims['sub'] }
 
+  ## Record not found error class
+  ## --------------------------------------------
+  ##
+  ## This is how you can tell Knock what error class to use for
+  ## record not found cases. By default, it assumes you have
+  ## ActiveRecord and will raise ActiveRecord::RecordNotFound.
+  ## If you are using Mongoid you can raise Mongoid::Errors::DocumentNotFound
+  ##
+  ##
+  ## Default:
+  # config.record_not_found_error_class = ActiveRecord::RecordNotFound
 
   ## Expiration claim
   ## ----------------

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -6,7 +6,7 @@ module Knock
   self.handle_attr = :email
 
   mattr_accessor :record_not_found_error_class
-  self.record_not_found_error_class = ActiveRecord::RecordNotFound
+  self.record_not_found_error_class =  ActiveRecord::RecordNotFound rescue NameError
 
   mattr_accessor :current_user_from_handle
   self.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -5,6 +5,9 @@ module Knock
   mattr_accessor :handle_attr
   self.handle_attr = :email
 
+  mattr_accessor :record_not_found_error_class
+  self.record_not_found_error_class = ActiveRecord::RecordNotFound
+
   mattr_accessor :current_user_from_handle
   self.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
 

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -6,7 +6,7 @@ module Knock
   self.handle_attr = :email
 
   mattr_accessor :record_not_found_error_class
-  self.record_not_found_error_class =  ActiveRecord::RecordNotFound rescue NameError
+  self.record_not_found_error_class = Mongoid::Errors::DocumentNotFound
 
   mattr_accessor :current_user_from_handle
   self.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -6,7 +6,7 @@ module Knock
   self.handle_attr = :email
 
   mattr_accessor :record_not_found_error_class
-  self.record_not_found_error_class = Mongoid::Errors::DocumentNotFound
+  self.record_not_found_error_class = Mongoid::Errors::DocumentNotFound rescue NameError
 
   mattr_accessor :current_user_from_handle
   self.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -5,8 +5,8 @@ module Knock
   mattr_accessor :handle_attr
   self.handle_attr = :email
 
-  mattr_accessor :record_not_found_error_class
-  self.record_not_found_error_class = Mongoid::Errors::DocumentNotFound rescue NameError
+  mattr_accessor :object_mapper
+  self.object_mapper = :active_record
 
   mattr_accessor :current_user_from_handle
   self.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
@@ -27,5 +27,13 @@ module Knock
   # a fresh initializer with all configuration values.
   def self.setup
     yield self
+  end
+
+  def self.record_not_found_error_class
+    if self.object_mapper == :active_record
+      Object.const_get('ActiveRecord::RecordNotFound')
+    elsif self.object_mapper == :mongoid
+      Object.const_get('Mongoid::Errors::DocumentNotFound')
+    end
   end
 end


### PR DESCRIPTION
Currently ActiveRecord is a dependency for this Gem. This PR allows to set the RecordNotFound error class from the config.