### PR TITLE
Fix typo in initializer template

### DIFF
--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -21,7 +21,7 @@ Knock.setup do |config|
   ## You must raise ActiveRecord::RecordNotFound if the resource cannot be retrieved.
   ##
   ## Default:
-  # self.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
+  # config.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
 
   ## Current user retrieval when validating token
   ## --------------------------------------------


### PR DESCRIPTION
This fixes a super minimal typo in the default initializer template that results in the following error when the line is uncommented: 

```
undefined method `current_user_from_handle=' for main:Object (NoMethodError)
from /Users/ntomlin/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/knock-1.3.0/lib/knock.rb:26:in `setup'
from /Users/ntomlin/workspace/auth/config/initializers/knock.rb:1:in `<top (required)>
```