### PR TITLE
add RSA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/dummy/.sass-cache
 coverage/
 *.gem
 Gemfile.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ test/dummy/.sass-cache
 coverage/
 *.gem
 Gemfile.lock
-.idea

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ class MyResourcesController < ApplicationController
 end
 ```
 
+If using RSA encryption, pass your public key when calling `authenticate`:
+
+```ruby
+before_action :authenticate_user
+
+  def authenticate_user
+    pubkey = OpenSSL::PKey::RSA.new(File.read('pubkey.pem'))
+    authenticate(key: pubkey)
+  end
+
+end
+```
+
 If no valid token is passed with the request, Knock will respond with:
 
 ```

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -4,9 +4,10 @@ module Knock
   class AuthToken
     attr_reader :token
 
-    def initialize payload: {}, token: nil
+    def initialize payload: {}, token: nil, decrypt_key: nil
       if token.present?
-        @payload, _ = JWT.decode token, key, true, verify_claims
+        decrypt_key ||= key
+        @payload, _ = JWT.decode token, decrypt_key, true, verify_claims
         @token = token
       else
         @payload = payload
@@ -18,7 +19,7 @@ module Knock
       @current_user ||= Knock.current_user_from_token.call @payload
     end
 
-  private
+    private
     def key
       Knock.token_secret_signature_key.call
     end

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -19,7 +19,7 @@ module Knock
       @current_user ||= Knock.current_user_from_token.call @payload
     end
 
-    private
+  private
     def key
       Knock.token_secret_signature_key.call
     end

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,10 +1,10 @@
 module Knock::Authenticable
   attr_reader :current_user
 
-  def authenticate
+  def authenticate(key: nil)
     begin
       token = request.headers['Authorization'].split(' ').last
-      @current_user = Knock::AuthToken.new(token: token).current_user
+      @current_user = Knock::AuthToken.new(token: token, decrypt_key: key).current_user
     rescue
       head :unauthorized
     end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
   email: one@example.net
   password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>
 

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'jwt'
-require 'json'
 
 module Knock
   class AuthTokenTest < ActiveSupport::TestCase

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'jwt'
+require 'json'
+
+module Knock
+  class AuthTokenTest < ActiveSupport::TestCase
+
+    def user
+      @user ||= users(:one)
+    end
+
+    test "decodes HSA with no key" do
+      payload = {sub: 1}
+      token = JWT.encode payload, Knock.token_secret_signature_key.call, 'HS256'
+
+      assert_equal(Knock::AuthToken.new(token: token).current_user, user)
+    end
+
+    test "decodes RSA with public key" do
+      payload = {sub: 1}
+      rsa_private = OpenSSL::PKey::RSA.generate 2048
+      rsa_public = rsa_private.public_key
+      token = JWT.encode payload, rsa_private, 'RS256'
+
+      assert_equal(Knock::AuthToken.new(token: token, decrypt_key: rsa_public).current_user, user)
+
+    end
+  end
+end


### PR DESCRIPTION
add key param to authenticate method
update auth_token model to support key param
update readme
tests for HSA and RSA decoding in auth_token model