### PR TITLE
Make it possible to just read current_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Contribution guidelines
 - URL authentication
 - Allow use of different encoding algorithm
+- Expose `current_user` in the controllers without authenticating
 
 ### Fixed
 - Audience verification in token

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ If no valid token is passed with the request, Knock will respond with:
 head :unauthorized
 ```
 
+If you just want to read the `current_user`, without actually authenticating, you can also do that:
+
+```ruby
+class CurrentUsersController < ApplicationController
+  def show
+    if current_user
+      head :ok
+    else
+      head :not_found
+    end
+  end
+end
+```
+
 ### Authenticating from a web or mobile application:
 
 Example request to get a token from your API:

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,7 +1,9 @@
 module Knock::Authenticable
   def current_user
     @current_user ||= begin
-      token = params[:token] || request.headers['Authorization'].split(' ').last
+      token = params[:token] ||
+        request.headers['Authorization'].match(/^Bearer (.*)$/)[1]
+
       Knock::AuthToken.new(token: token).current_user
     rescue
       nil

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,12 +1,14 @@
 module Knock::Authenticable
-  attr_reader :current_user
+  def current_user
+    @current_user ||= begin
+      token = request.headers['Authorization'].split(' ').last
+      Knock::AuthToken.new(token: token).current_user
+    rescue
+      nil
+    end
+  end
 
   def authenticate
-    begin
-      token = request.headers['Authorization'].split(' ').last
-      @current_user = Knock::AuthToken.new(token: token).current_user
-    rescue
-      head :unauthorized
-    end
+    head :unauthorized unless current_user
   end
 end

--- a/test/dummy/app/controllers/current_users_controller.rb
+++ b/test/dummy/app/controllers/current_users_controller.rb
@@ -1,0 +1,9 @@
+class CurrentUsersController < ApplicationController
+  def show
+    if current_user
+      head :ok
+    else
+      head :not_found
+    end
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :protected_resources
+  resource :current_user
   mount Knock::Engine => "/knock"
 end

--- a/test/dummy/test/controllers/current_users_controller_test.rb
+++ b/test/dummy/test/controllers/current_users_controller_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class CurrentUsersControllerTest < ActionController::TestCase
+  setup do
+    @user = users(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @user.id }).token
+  end
+
+  def authenticate token: @token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token}"
+  end
+
+  test "responds with 404 if user is not logged in" do
+    get :show
+    assert_response :not_found
+  end
+
+  test "responds with 200" do
+    authenticate
+    get :show
+    assert_response :success
+  end
+end


### PR DESCRIPTION
I have a use case, where I want to do A if there is a user, and B if there is no user.

So I need to read the `current_user` without doing anything if it isn't there.

I know you're in the midst of version 2.0, but just wanted to get this idea in here.
