### PR TITLE
Bugfix: Audience not being verified

### DIFF
--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -32,7 +32,7 @@ module Knock
 
     def verify_claims
       {
-        aud: Knock.token_audience, verify_claims: Knock.token_audience.present?
+        aud: Knock.token_audience, verify_aud: Knock.token_audience.present?
       }
     end
   end

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'jwt'
+
+module Knock
+  class AuthTokenTest < ActiveSupport::TestCase
+    setup do
+      Knock.token_secret_signature_key = -> { 'secret' }
+    end
+
+    test "verifies audience when token_audience is present" do
+      Knock.token_audience = 'foobar'
+      token = JWT.encode({ sub: 'foo' }, 'secret', 'HS256')
+
+      assert_raises(JWT::InvalidAudError) {
+        AuthToken.new token: token
+      }
+    end
+  end
+end


### PR DESCRIPTION
I was reading through both the knock and ruby-jwt sources and noticed `verify_claims` is [not a valid jwt decode option](https://github.com/jwt/ruby-jwt/blob/jwt-1.5.2/lib/jwt.rb#L140-L146). Switched it to `verify_aud`.