### PR TITLE
Allow URL authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Travis integration
 - Contribution guidelines
+- URL authentication
 
 ### Fixed
 - Audience verification in token

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -3,7 +3,7 @@ module Knock::Authenticable
 
   def authenticate
     begin
-      token = request.headers['Authorization'].split(' ').last
+      token = params[:token] || request.headers['Authorization'].split(' ').last
       @current_user = Knock::AuthToken.new(token: token).current_user
     rescue
       head :unauthorized

--- a/test/dummy/test/controllers/protected_resources_controller_test.rb
+++ b/test/dummy/test/controllers/protected_resources_controller_test.rb
@@ -1,10 +1,13 @@
 require 'test_helper'
 
 class ProtectedResourcesControllerTest < ActionController::TestCase
-  def authenticate
+  def setup
     @user = users(:one)
     @token = Knock::AuthToken.new(payload: { sub: @user.id }).token
-    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def authenticate token: @token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token}"
   end
 
   test "responds with unauthorized" do
@@ -12,10 +15,26 @@ class ProtectedResourcesControllerTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
-  test "responds with success if authenticated" do
+  test "responds with success with valid token in header" do
     authenticate
     get :index
     assert_response :success
+  end
+
+  test "responds with unauthorized with invalid token in header" do
+    authenticate token: "invalid"
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with success with token in url" do
+    get :index, token: @token
+    assert_response :success
+  end
+
+  test "responds with unauthorized with invalid token in url" do
+    get :index, token: "invalid"
+    assert_response :unauthorized
   end
 
   test "has a current_user after authentication" do


### PR DESCRIPTION
### Context

As an alternative to passing the token via the request header, we want to be able to pass the token via the query parameters.

example: `GET /protected?token=XXX`

### Implementation

- The `Authenticable#authenticate` method now looks for a `token` param before falling back to the request header.

### Notes

This closes #17 