### PR TITLE
Allow use of different signing algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Travis integration
 - Contribution guidelines
 - URL authentication
+- Allow use of different encoding algorithm
 
 ### Fixed
 - Audience verification in token

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ class MyResourcesControllerTest < ActionController::TestCase
 end
 ```
 
+### Algorithms
+
+The JWT spec supports different kind of cryptographic signing algorithms.
+You can set `token_signature_algorithm` to use the one you want in the
+initializer or do nothing and use the default one (HS256).
+
+You can specify any of the algorithms supported by the
+[jwt](https://github.com/jwt/ruby-jwt) gem.
+
+If the algorithm you use requires a public key, you also need to set
+`token_public_key` in the initializer.
+
 ## CORS
 
 To enable cross-origin resource sharing, check out the [rack-cors](https://github.com/cyu/rack-cors) gem.

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -57,6 +57,13 @@ Knock.setup do |config|
   ## If using Auth0, uncomment the line below
   # config.token_audience = -> { Rails.application.secrets.auth0_client_id }
 
+  ## Signature algorithm
+  ## -------------------
+  ##
+  ## Configure the algorithm used to encode the token
+  ##
+  ## Default:
+  # config.token_signature_algorithm = 'HS256'
 
   ## Signature key
   ## -------------
@@ -69,4 +76,11 @@ Knock.setup do |config|
   ## If using Auth0, uncomment the line below
   # config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }
 
+  ## Public key
+  ## ----------
+  ##
+  ## Configure the public key used to decode tokens, if required.
+  ##
+  ## Default:
+  # config.token_public_key = nil
 end

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -17,8 +17,14 @@ module Knock
   mattr_accessor :token_audience
   self.token_audience = nil
 
+  mattr_accessor :token_signature_algorithm
+  self.token_signature_algorithm = 'HS256'
+
   mattr_accessor :token_secret_signature_key
   self.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+
+  mattr_accessor :token_public_key
+  self.token_public_key = nil
 
   # Default way to setup Knock. Run `rails generate knock:install` to create
   # a fresh initializer with all configuration values.

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -4,12 +4,48 @@ require 'jwt'
 module Knock
   class AuthTokenTest < ActiveSupport::TestCase
     setup do
+      Knock.token_signature_algorithm = 'HS256'
       Knock.token_secret_signature_key = -> { 'secret' }
+      Knock.token_public_key = nil
+      Knock.token_audience = nil
     end
 
-    test "verifies audience when token_audience is present" do
-      Knock.token_audience = 'foobar'
-      token = JWT.encode({ sub: 'foo' }, 'secret', 'HS256')
+    test "verify algorithm" do
+      Knock.token_signature_algorithm = 'RS256'
+      token = JWT.encode({sub: '1'}, 'secret', 'HS256')
+
+      assert_raises(JWT::IncorrectAlgorithm) {
+        AuthToken.new(token: token)
+      }
+    end
+
+    test "decode RSA encoded tokens" do
+      user = users(:one)
+      rsa_private = OpenSSL::PKey::RSA.generate 2048
+      Knock.token_public_key = rsa_private.public_key
+      Knock.token_signature_algorithm = 'RS256'
+
+      token = JWT.encode({sub: user.id}, rsa_private, 'RS256')
+
+      assert_nothing_raised { AuthToken.new(token: token) }
+    end
+
+    test "encode tokens with RSA" do
+      rsa_private = OpenSSL::PKey::RSA.generate 2048
+      Knock.token_secret_signature_key = -> { rsa_private }
+      Knock.token_signature_algorithm = 'RS256'
+
+      token = AuthToken.new(payload: {sub: '1'}).token
+
+      payload, header = JWT.decode token, rsa_private.public_key, true
+      assert_equal payload['sub'], '1'
+      assert_equal header['alg'], 'RS256'
+    end
+
+    test "verify audience when token_audience is present" do
+      Knock.token_audience = 'bar'
+
+      token = JWT.encode({sub: 'foo'}, 'secret', 'HS256')
 
       assert_raises(JWT::InvalidAudError) {
         AuthToken.new token: token


### PR DESCRIPTION
### Context

We want to be able to specify a different encoding / decoding algorithm for the tokens. See [jwt/ruby-jwt](https://github.com/jwt/ruby-jwt) for the list of supported algorithms.

### Implementation

- [x] Update CHANGELOG.md
- [x] Update README.md
- [x] Add `token_signature_algorithm` to configuration to specify algorithm or use [jwt/ruby-jwt](https://github.com/jwt/ruby-jwt)'s default.
- [x] Add `token_public_key` configuration variable to specify public key if necessary
- [x] Use public key for decoding if present
- [x] Explicitly enforce use of correct algorithm when decoding token

### Notes

This closes #21 