### PR TITLE
Bugfix: Audience verification not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fixed audience verification in token (was not working with lambdas)
+
 ## [1.4.0] - 2016-01-02
 ### Changed
 - Allow use of rails versions above 4.2

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -38,14 +38,22 @@ module Knock
     def claims
       {
         exp: Knock.token_lifetime.from_now.to_i,
-        aud: Knock.token_audience
+        aud: token_audience
       }
     end
 
     def verify_claims
       {
-        aud: Knock.token_audience, verify_aud: Knock.token_audience.present?
+        aud: token_audience, verify_aud: verify_audience?
       }
+    end
+
+    def token_audience
+      verify_audience? && Knock.token_audience.call
+    end
+
+    def verify_audience?
+      Knock.token_audience.present?
     end
   end
 end

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -38,7 +38,7 @@ module Knock
     end
 
     test "verify audience when token_audience is present" do
-      Knock.token_audience = 'bar'
+      Knock.token_audience = -> { 'bar' }
       key = Knock.token_secret_signature_key.call
 
       token = JWT.encode({sub: 'foo'}, key, 'HS256')


### PR DESCRIPTION
Recent fix to audience verification (https://github.com/nsarno/knock/pull/25) has exposed the inconsistency between how audience_token is set in the [config](https://github.com/nsarno/knock/blob/master/lib/generators/templates/knock.rb#L58):
```rb
config.token_audience = -> { Rails.application.secrets.auth0_client_id }
```
And the way it was verified in the auth_token.rb. As a result out of the box setup with Auth0 is broken when upgrading to 1.4.0.

In keeping consistency with the rest of the code, token_audience should be a lambda and should thus be called during verification.

I did not add new tests, just corrected existing ones to work with a correct input since they already cover all the necessary cases. Let me know if this is not sufficient.