### PR TITLE
Fix test guidance in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ e.g.
 class MyResourcesControllerTest < ActionController::TestCase
   def authenticate
     token = Knock::AuthToken.new(payload: { sub: users(:one).id }).token
-    request.env['HTTP_AUTHORIZATION'] = "bearer #{token}"
+    request.env['HTTP_AUTHORIZATION'] = "Bearer #{token}"
   end
 
   setup do


### PR DESCRIPTION
Since #31 Bearer in the authorization header must be titleized, otherwise the request is not being authorized. However, the Readme still refers to lower-case *bearer* which does not work.

This is also consistent with how knock's own tests are written.