### PR TITLE
Fix auth header parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.4.2] - 2016-01-29
 ### Fixed
 - Allow use of any or no prefix in authorization header.
 This fixes an unwanted breaking change introduced in `1.4.0` forcing the use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Allow use of any or no prefix in authorization header.
+This fixes an unwanted breaking change introduced in `1.4.0` forcing the use
+of the `Bearer` prefix.
+
 ## [1.4.1] - 2016-01-08
 ### Fixed
 - Use lambda for audience verification

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,9 +1,7 @@
 module Knock::Authenticable
   def current_user
     @current_user ||= begin
-      token = params[:token] ||
-        request.headers['Authorization'].match(/^Bearer (.*)$/)[1]
-
+      token = params[:token] || request.headers['Authorization'].split.last
       Knock::AuthToken.new(token: token).current_user
     rescue
       nil

--- a/lib/knock/version.rb
+++ b/lib/knock/version.rb
@@ -1,3 +1,3 @@
 module Knock
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end

--- a/test/dummy/test/controllers/protected_resources_controller_test.rb
+++ b/test/dummy/test/controllers/protected_resources_controller_test.rb
@@ -43,4 +43,20 @@ class ProtectedResourcesControllerTest < ActionController::TestCase
     assert_response :success
     assert @controller.current_user.id == @user.id
   end
+
+  test "accepts any prefix in the authorization header" do
+    @request.env['HTTP_AUTHORIZATION'] = "Other #{@token}"
+
+    get :index
+
+    assert_response :success
+  end
+
+  test "accepts authorization header without prefix" do
+    @request.env['HTTP_AUTHORIZATION'] = "#{@token}"
+
+    get :index
+
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Revert to parsing the authorization header in a more flexible way by not enforcing the presence of a specific prefix.

- Fixes an unwanted breaking change introduced in `1.4.0` forcing the use of the `Bearer` prefix.
- Closes #36 
