### PR TITLE
Deprecate `Knock::Authenticable` in favor of `Knock::Authenticable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Deprecate `Knock::Authenticable` in favor of `Knock::Authenticatable`
+
 ## [1.4.2] - 2016-01-29
 ### Fixed
 - Allow use of any or no prefix in authorization header.

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Rails.application.routes.draw do
 end
 ```
 
-Then include the `Knock::Authenticable` module in your `ApplicationController`
+Then include the `Knock::Authenticatable` module in your `ApplicationController`
 
 ```ruby
 class ApplicationController < ActionController::API
-  include Knock::Authenticable
+  include Knock::Authenticatable
 end
 ```
 

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -1,4 +1,5 @@
 require "knock/engine"
+require "knock/authenticatable"
 
 module Knock
 
@@ -30,5 +31,28 @@ module Knock
   # a fresh initializer with all configuration values.
   def self.setup
     yield self
+  end
+
+  def self.const_missing(const_name)
+    valid_const = deprecated_constants[const_name]
+    const_warning(const_name) if valid_const
+    valid_const || super
+  end
+
+  def self.deprecated_constants
+    {
+      Authenticable: Authenticatable,
+    }
+  end
+
+  private
+
+  def self.const_warning(const_name)
+    @const_warning ||= false
+    unless @const_warning
+      $stderr.puts "WARNING: Deprecated reference to constant '#{const_name}'"
+      $stderr.puts "Use '#{deprecated_constants[const_name]}' instead"
+    end
+    @const_warning = true
   end
 end

--- a/lib/knock/authenticatable.rb
+++ b/lib/knock/authenticatable.rb
@@ -1,4 +1,4 @@
-module Knock::Authenticable
+module Knock::Authenticatable
   def current_user
     @current_user ||= begin
       token = params[:token] || request.headers['Authorization'].split.last

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -3,5 +3,5 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
 
-  include Knock::Authenticable
+  include Knock::Authenticatable
 end

--- a/test/knock_test.rb
+++ b/test/knock_test.rb
@@ -1,9 +1,22 @@
 require 'test_helper'
 
+module Knock
+  private
+
+  def self.const_warning(const_name)
+    # avoid output to stderr when testing deprecated constants
+  end
+end
+
 class KnockTest < ActiveSupport::TestCase
   test 'setup block yields self' do
     Knock.setup do |config|
       assert_equal Knock, config
     end
+  end
+
+  test 'Knock::Authenticable is deprecated' do
+    assert_equal Knock::Authenticable, Knock::Authenticatable
+    assert_equal Knock.deprecated_constants[:Authenticable].nil?, false
   end
 end


### PR DESCRIPTION
### Why

"Authenticable" doesn't seem to be valid english. Use the term "Authenticatable" instead.

### How

- Rename `Authenticable` module to `Authenticatable`
- Fire a warning and return `Knock::Authenticatable` if the deprecated
	module is called
- Test deprecation of module in `test/knock_test.rb`
- Update the `CHANGELOG` and `README`