### PR TITLE
make ActiveRecord::NotFound exception configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
 - 2.1.0
+- 2.1.7
+- 2.3.0
 addons:
   code_climate:
     repo_token: 61c3ea804322306871a6b7e06a0a6435672cd29aea0c2b286e6b837234ba9d90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- adding config options for exception class
+
 ## [1.4.2] - 2016-01-29
 ### Fixed
 - Allow use of any or no prefix in authorization header.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,24 @@ class MyResourcesControllerTest < ActionController::TestCase
 end
 ```
 
+#### Without ActiveRecord
+
+If no ActiveRecord is used, then you will need to specify what Exception will be used when the user is not found with the given credentials.
+
+```ruby
+Knock.setup do |config|
+
+  # Exception Class
+  # ---------------
+  #
+  # Configure the Exception to be used (raised and rescued) for User Not Found.
+  # note: change this if ActiveRecord is not being used.
+  #
+  # Default:
+  config.not_found_exception_class_name = 'MyCustomException'
+end
+```
+
 ### Algorithms
 
 The JWT spec supports different kind of cryptographic signing algorithms.

--- a/app/controllers/knock/application_controller.rb
+++ b/app/controllers/knock/application_controller.rb
@@ -1,6 +1,6 @@
 module Knock
   class ApplicationController < ActionController::Base
-    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+    rescue_from Knock.not_found_exception_class_name, with: :not_found
 
   private
 

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -10,7 +10,7 @@ module Knock
 
   private
     def authenticate!
-      raise ActiveRecord::RecordNotFound unless user.authenticate(auth_params[:password])
+      raise Knock.not_found_exception_class unless user.authenticate(auth_params[:password])
     end
 
     def auth_token

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -18,7 +18,9 @@ Knock.setup do |config|
   ## AuthTokenController parameters. It also uses the same variable to enforce
   ## permitted values in the controller.
   ##
-  ## You must raise ActiveRecord::RecordNotFound if the resource cannot be retrieved.
+  ## You must raise an exception if the resource cannot be retrieved.
+  ## The type of the exception is configured in config.not_found_exception_class_name,
+  ## and it is ActiveRecord::RecordNotFound by default
   ##
   ## Default:
   # config.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
@@ -30,7 +32,9 @@ Knock.setup do |config|
   ## By default, it assumes you have a model called `User` and that
   ## the user_id is stored in the 'sub' claim.
   ##
-  ## You must raise ActiveRecord::RecordNotFound if the resource cannot be retrieved.
+  ## You must raise an exception if the resource cannot be retrieved.
+  ## The type of the exception is configured in config.not_found_exception_class_name,
+  ## and it is ActiveRecord::RecordNotFound by default
   ##
   ## Default:
   # config.current_user_from_token = -> (claims) { User.find claims['sub'] }
@@ -83,4 +87,13 @@ Knock.setup do |config|
   ##
   ## Default:
   # config.token_public_key = nil
+
+  ## Exception Class
+  ## ---------------
+  ##
+  ## Configure the Exception to be used (raised and rescued) for User Not Found.
+  ## note: change this if ActiveRecord is not being used.
+  ##
+  ## Default:
+  # config.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'
 end

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -26,6 +26,13 @@ module Knock
   mattr_accessor :token_public_key
   self.token_public_key = nil
 
+  mattr_accessor :not_found_exception_class_name
+  self.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'
+
+  def self.not_found_exception_class
+    not_found_exception_class_name.to_s.constantize
+  end
+
   # Default way to setup Knock. Run `rails generate knock:install` to create
   # a fresh initializer with all configuration values.
   def self.setup

--- a/test/controllers/knock/auth_token_controller_test.rb
+++ b/test/controllers/knock/auth_token_controller_test.rb
@@ -10,6 +10,10 @@ module Knock
       @user ||= users(:one)
     end
 
+    test "it's using configured custom exception" do
+      assert_equal Knock.not_found_exception_class, Knock::MyCustomException
+    end
+
     test "responds with 404 if user does not exist" do
       post :create, auth: { email: 'wrong@example.net', password: '' }
       assert_response :not_found

--- a/test/dummy/config/initializers/knock.rb
+++ b/test/dummy/config/initializers/knock.rb
@@ -1,0 +1,10 @@
+Knock.setup do |config|
+  config.token_signature_algorithm = 'HS256'
+  config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+  config.token_public_key = nil
+  config.token_audience = nil
+
+  config.current_user_from_handle = -> handle { User.find_by(Knock.handle_attr => handle) || raise(Knock::MyCustomException) }
+  config.current_user_from_token = -> claims { User.find_by(id: claims['sub']) || raise(Knock::MyCustomException) }
+  config.not_found_exception_class_name = 'Knock::MyCustomException'
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,11 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures :all
 end
 
+module Knock
+  class MyCustomException < StandardError
+  end
+end
+
 # Make sure knock global configuration is reset before every tests
 # to avoid order dependent failures.
 class ActiveSupport::TestCase
@@ -34,5 +39,9 @@ class ActiveSupport::TestCase
     Knock.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
     Knock.token_public_key = nil
     Knock.token_audience = nil
+
+    Knock.current_user_from_handle = -> handle { User.find_by(Knock.handle_attr => handle) || raise(Knock::MyCustomException) }
+    Knock.current_user_from_token = -> claims { User.find_by(id: claims['sub']) || raise(Knock::MyCustomException) }
+    Knock.not_found_exception_class_name = 'Knock::MyCustomException'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,9 +39,5 @@ class ActiveSupport::TestCase
     Knock.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
     Knock.token_public_key = nil
     Knock.token_audience = nil
-
-    Knock.current_user_from_handle = -> handle { User.find_by(Knock.handle_attr => handle) || raise(Knock::MyCustomException) }
-    Knock.current_user_from_token = -> claims { User.find_by(id: claims['sub']) || raise(Knock::MyCustomException) }
-    Knock.not_found_exception_class_name = 'Knock::MyCustomException'
   end
 end


### PR DESCRIPTION
in order to use other exceptions, if no ActiveRecord is used.