### PR TITLE
Fixing the resource getter

### DIFF
--- a/lib/knock/authenticatable.rb
+++ b/lib/knock/authenticatable.rb
@@ -32,7 +32,7 @@ module Knock::Authenticatable
   end
 
   def define_current_resource_getter resource_class
-    self.class.send(:define_method, "current_#{resource_class.to_s.downcase}") do
+    self.class.send(:define_method, "current_#{resource_class.underscore}") do
       @resource
     end
   end


### PR DESCRIPTION
It should be underscore because in a case of an N word entity | N > 1, it will produce a wrong getter name, i.e.: AdminUser will became adminuser instead of admin_user.