### PR TITLE
Fixing resource getter and generator for classes with more than one word

### DIFF
--- a/lib/generators/templates/resource_token_controller.rb.erb
+++ b/lib/generators/templates/resource_token_controller.rb.erb
@@ -1,2 +1,2 @@
-class <%= resource_name.capitalize %>TokenController < Knock::AuthTokenController
+class <%= resource_name.camelize %>TokenController < Knock::AuthTokenController
 end

--- a/lib/knock/authenticatable.rb
+++ b/lib/knock/authenticatable.rb
@@ -32,7 +32,7 @@ module Knock::Authenticatable
   end
 
   def define_current_resource_getter resource_class
-    self.class.send(:define_method, "current_#{resource_class.to_s.downcase}") do
+    self.class.send(:define_method, "current_#{resource_class.to_s.underscore}") do
       @resource
     end
   end

--- a/test/dummy/app/controllers/admin_user_protected_controller.rb
+++ b/test/dummy/app/controllers/admin_user_protected_controller.rb
@@ -1,0 +1,7 @@
+class AdminUserProtectedController < ApplicationController
+  before_action :authenticate_admin_user
+
+  def index
+    head :ok
+  end
+end

--- a/test/dummy/app/controllers/admin_user_token_controller.rb
+++ b/test/dummy/app/controllers/admin_user_token_controller.rb
@@ -1,0 +1,2 @@
+class AdminUserTokenController < Knock::AuthTokenController
+end

--- a/test/dummy/app/models/admin_user.rb
+++ b/test/dummy/app/models/admin_user.rb
@@ -1,0 +1,3 @@
+class AdminUser < ActiveRecord::Base
+  has_secure_password
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
+  post 'admin_user_token' => 'admin_user_token#create'
   post 'user_token' => 'user_token#create'
   post 'admin_token' => 'admin_token#create'
+
   resources :user_protected
   resources :admin_protected
+  resources :admin_user_protected
 end

--- a/test/dummy/db/migrate/20160427035056_create_admin_users.rb
+++ b/test/dummy/db/migrate/20160427035056_create_admin_users.rb
@@ -1,0 +1,10 @@
+class CreateAdminUsers < ActiveRecord::Migration
+  def change
+    create_table :admin_users do |t|
+      t.string :email, unique: true, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922015152) do
+ActiveRecord::Schema.define(version: 20160427035056) do
+
+  create_table "admin_users", force: :cascade do |t|
+    t.string   "email",           null: false
+    t.string   "password_digest", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
 
   create_table "admins", force: :cascade do |t|
     t.string   "email",           null: false

--- a/test/dummy/test/controllers/admin_user_protected_controller_test.rb
+++ b/test/dummy/test/controllers/admin_user_protected_controller_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class AdminUserProtectedControllerTest < ActionController::TestCase
+  def valid_auth
+    @admin_user = admin_users(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @admin_user.id }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  test "has a current_admin_user after authentication" do
+    valid_auth
+    get :index
+    assert_response :success
+    assert @controller.current_admin_user.id == @admin_user.id
+  end
+end

--- a/test/dummy/test/models/admin_user_test.rb
+++ b/test/dummy/test/models/admin_user_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class AdminUserTest < ActiveSupport::TestCase
+end

--- a/test/fixtures/admin_users.yml
+++ b/test/fixtures/admin_users.yml
@@ -1,0 +1,3 @@
+one:
+  email: admin_user.one@example.net
+  password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>

--- a/test/generators/token_controller_generator_test.rb
+++ b/test/generators/token_controller_generator_test.rb
@@ -15,5 +15,17 @@ class TokenControllerGeneratorTest < Rails::Generators::TestCase
 
     run_generator ['Admin']
     assert_file "app/controllers/user_token_controller.rb"
+
+    run_generator ['AdminUser']
+    assert_file "app/controllers/admin_user_token_controller.rb"
+
+    require File.join(destination_root, "app/controllers/admin_user_token_controller.rb")
+    assert Object.const_defined?('AdminUserTokenController'), 'uninitialized constant AdminUserTokenController'
+
+    run_generator ['user_admin']
+    assert_file "app/controllers/user_admin_token_controller.rb"
+
+    require File.join(destination_root, "app/controllers/user_admin_token_controller.rb")
+    assert Object.const_defined?('UserAdminTokenController'), 'uninitialized constant UserAdminTokenController'
   end
 end


### PR DESCRIPTION
It should be underscore on the resource getter and camelize on generator for models with two or more words. Also allowing to generate the controller passing either underscored or camelized model name