### PR TITLE
Possibility to have permanent tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+## Added
+- Possibility to have permanent tokens
 - adding config options for exception class
 
 ## [1.4.2] - 2016-01-29
@@ -65,4 +67,3 @@ of the `Bearer` prefix.
 - `Knock::Authenticable` to secure endpoints with `before_action :authenticate`
 - `AuthToken` model provides JWT encapsulation
 - `AuthTokenController` provides out of the box sign in implementation
-

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -3,6 +3,7 @@ require 'jwt'
 module Knock
   class AuthToken
     attr_reader :token
+    attr_reader :payload
 
     def initialize payload: {}, token: nil
       if token.present?
@@ -36,15 +37,25 @@ module Knock
     end
 
     def claims
-      {
-        exp: Knock.token_lifetime.from_now.to_i,
-        aud: token_audience
-      }
+      _claims = {}
+      _claims[:exp] = token_lifetime if verify_lifetime?
+      _claims[:aud] = token_audience if verify_audience?
+      _claims
+    end
+
+    def token_lifetime
+      Knock.token_lifetime.from_now.to_i if verify_lifetime?
+    end
+
+    def verify_lifetime?
+      !Knock.token_lifetime.nil?
     end
 
     def verify_claims
       {
-        aud: token_audience, verify_aud: verify_audience?
+        aud: token_audience,
+        verify_aud: verify_audience?,
+        verify_expiration: verify_lifetime?
       }
     end
 

--- a/knock.gemspec
+++ b/knock.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency "bcrypt", "~> 3.1"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
+  s.add_development_dependency "timecop", "~> 0.8.0"
 end

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -43,7 +43,8 @@ Knock.setup do |config|
   ## Expiration claim
   ## ----------------
   ##
-  ## How long before a token is expired.
+  ## How long before a token is expired. If nil is provided, token will
+  ## last forever.
   ##
   ## Default:
   # config.token_lifetime = 1.day

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,5 +39,6 @@ class ActiveSupport::TestCase
     Knock.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
     Knock.token_public_key = nil
     Knock.token_audience = nil
+    Knock.token_lifetime = 1.day
   end
 end


### PR DESCRIPTION
Now, when setting `token_lifetime` to `nil` on initializer, it doesn't validate the exp claim anymore.