### PR TITLE
[v1.5] Multiple entities authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Exception configuration option `Knock.not_found_exception_class_name`
 - Multiple entity authentication (e.g. User, Admin, etc)
 - Possibility to have permanent tokens
-- adding config options for exception class
+- Adding config options for exception class
+- Generator for token controller. E.g. `rails g knock:token_controller user`
 
 ### Changed
 - Deprecated `Authenticable#authenticate` in favor of `Authenticable#authenticate_user`
 - Deprecated use of `Knock.current_user_from_token` in favor of `User.find_for_authentication`
+- Deprecated use of direct route to `AuthTokenController` in favor of generating  a token controller
+- No need to mount the engine in `config/routes.rb` anymore
 
 ## [1.4.2] - 2016-01-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-## Added
+## [Unreleased] - Unreleased
+### Added
+- Exception configuration option `Knock.not_found_exception_class_name`
+- Multiple entity authentication (e.g. User, Admin, etc)
 - Possibility to have permanent tokens
 - adding config options for exception class
+
+### Changed
+- Deprecated `Authenticable#authenticate` in favor of `Authenticable#authenticate_user`
+- Deprecated use of `Knock.current_user_from_token` in favor of `User.find_for_authentication`
 
 ## [1.4.2] - 2016-01-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Deprecated `Authenticable#authenticate` in favor of `Authenticable#authenticate_user`
-- Deprecated use of `Knock.current_user_from_token` in favor of `User.find_for_authentication`
+- Deprecated use of `Knock.current_user_from_token` in favor of `User.from_token_payload`
 - Deprecated use of direct route to `AuthTokenController` in favor of generating  a token controller
 - No need to mount the engine in `config/routes.rb` anymore
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing Guidelines
 
 Contribution is always highly appreciated. Here are a few guidelines to make it
-easier and faster for pull requests to get merged and issues to get fixed. 
+easier and faster for pull requests to get merged and issues to get fixed.
 
 ### Issues
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 gem "codeclimate-test-reporter", group: :test, require: nil
+gem "simplecov", require: false, group: :test

--- a/README.md
+++ b/README.md
@@ -117,7 +117,69 @@ Note: the `authenticate_user` method uses the `current_user` method. Overwriting
 
 You can do the exact same thing for any entity. E.g. for `Admin`, use `authenticate_admin` and `current_admin` instead.
 
-### Authenticating from a web or mobile application:
+### Customization
+
+#### Via the entity model
+
+The entity model (e.g. `User`) can implement specific methods to provide
+customization over different part of the authentication process.
+
+- Find the entity when creating the token (when signing in)
+
+By default, Knock tries to find the entity by email. If you want to modify this
+behaviour, implement in your entity model a class method `find_for_token_creation`
+that takes the request in argument.
+
+E.g.
+
+```ruby
+class User < ActiveRecord::Base
+  def self.find_for_token_creation request
+    # Returns a valid user, `nil` or raise `Knock.not_found_exception_class_name`
+  end
+end
+```
+
+- Find the authenticated entity from the token payload (when authenticating a request)
+
+By default, Knock assumes the payload as a subject (`sub`) claim containing the entity's id
+and calls `find` on the model. If you want to modify this behaviour, implement in
+your entity model a class method `find_for_authentication` that takes the
+payload in argument.
+
+E.g.
+
+```ruby
+class User < ActiveRecord::Base
+  def self.find_for_authentication payload
+    # Returns a valid user, `nil` or raise
+  end
+end
+```
+
+- Modify the token payload
+
+By default the token payload contains the entity's id inside the subject (`sub`) claim.
+If you want to modify this behaviour, implement in your entity model an instance method
+`to_token_payload` that returns a hash representing the payload.
+
+E.g.
+
+```ruby
+class User < ActiveRecord::Base
+  def to_token_payload
+    # Returns the payload as a hash
+  end
+end
+```
+
+#### Via the initializer
+
+The initializer [config/initializers/knock.rb](https://github.com/nsarno/knock/blob/master/lib/generators/templates/knock.rb)
+is generated when `rails g knock:install` is executed. Each configuration variable is
+documented with comments in the initializer itself.
+
+### Authenticating from a web or mobile application
 
 Example request to get a token from your API:
 ```

--- a/README.md
+++ b/README.md
@@ -124,40 +124,45 @@ You can do the exact same thing for any entity. E.g. for `Admin`, use `authentic
 The entity model (e.g. `User`) can implement specific methods to provide
 customization over different part of the authentication process.
 
-- Find the entity when creating the token (when signing in)
+- **Find the entity when creating the token (when signing in)**
 
 By default, Knock tries to find the entity by email. If you want to modify this
-behaviour, implement in your entity model a class method `find_for_token_creation`
+behaviour, implement in your entity model a class method `from_token_request`
 that takes the request in argument.
 
 E.g.
 
 ```ruby
 class User < ActiveRecord::Base
-  def self.find_for_token_creation request
+  def self.from_token_request request
     # Returns a valid user, `nil` or raise `Knock.not_found_exception_class_name`
+    # e.g.
+    #   email = request.params["auth"] && request.params["auth"]["email"]
+    #   self.find_by email: email
   end
 end
 ```
 
-- Find the authenticated entity from the token payload (when authenticating a request)
+- **Find the authenticated entity from the token payload (when authenticating a request)**
 
 By default, Knock assumes the payload as a subject (`sub`) claim containing the entity's id
 and calls `find` on the model. If you want to modify this behaviour, implement in
-your entity model a class method `find_for_authentication` that takes the
+your entity model a class method `from_token_payload` that takes the
 payload in argument.
 
 E.g.
 
 ```ruby
 class User < ActiveRecord::Base
-  def self.find_for_authentication payload
+  def self.from_token_payload payload
     # Returns a valid user, `nil` or raise
+    # e.g.
+    #   self.find payload["sub"]
   end
 end
 ```
 
-- Modify the token payload
+- **Modify the token payload**
 
 By default the token payload contains the entity's id inside the subject (`sub`) claim.
 If you want to modify this behaviour, implement in your entity model an instance method

--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ Knock is an authentication solution for Rails API-only application based on JSON
 
 Yes.
 
-### Upcoming features & improvements
-
-- Easy way to authenticate multiple user types (User, Admin, ...)
-- Remove ActiveRecord dependency
-
-Really want some feature? Don't hesitate to open an issue :)
-
 ## Getting Started
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class SecuredController < ApplicationController
 end
 ```
 
-You can access the currently authenticated user in your controller with `current_user`.
+You can access the current user in your controller with `current_user`.
 
 If no valid token is passed with the request, Knock will respond with:
 
@@ -113,7 +113,7 @@ def index
 end
 ```
 
-Note: the `authenticate_user` method uses the `current_user` method. Overwriting `current_user` may cause unexpected behaviours.
+Note: the `authenticate_user` method uses the `current_user` method. Overwriting `current_user` may cause unexpected behaviour.
 
 You can do the exact same thing for any entity. E.g. for `Admin`, use `authenticate_admin` and `current_admin` instead.
 
@@ -122,12 +122,12 @@ You can do the exact same thing for any entity. E.g. for `Admin`, use `authentic
 #### Via the entity model
 
 The entity model (e.g. `User`) can implement specific methods to provide
-customization over different part of the authentication process.
+customization over different parts of the authentication process.
 
 - **Find the entity when creating the token (when signing in)**
 
 By default, Knock tries to find the entity by email. If you want to modify this
-behaviour, implement in your entity model a class method `from_token_request`
+behaviour, implement within your entity model a class method `from_token_request`
 that takes the request in argument.
 
 E.g.
@@ -146,7 +146,7 @@ end
 - **Find the authenticated entity from the token payload (when authenticating a request)**
 
 By default, Knock assumes the payload as a subject (`sub`) claim containing the entity's id
-and calls `find` on the model. If you want to modify this behaviour, implement in
+and calls `find` on the model. If you want to modify this behaviour, implement within
 your entity model a class method `from_token_payload` that takes the
 payload in argument.
 
@@ -165,7 +165,7 @@ end
 - **Modify the token payload**
 
 By default the token payload contains the entity's id inside the subject (`sub`) claim.
-If you want to modify this behaviour, implement in your entity model an instance method
+If you want to modify this behaviour, implement within your entity model an instance method
 `to_token_payload` that returns a hash representing the payload.
 
 E.g.
@@ -198,7 +198,7 @@ Example response from the API:
 {"jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"}
 ```
 
-To make an authenticated request to your API, you need to pass the token in the request header:
+To make an authenticated request to your API, you need to pass the token via the request header:
 ```
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9
 GET /my_resources

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -16,7 +16,11 @@ module Knock
     end
 
     def auth_token
-      AuthToken.new payload: { sub: entity.id }
+      if entity.respond_to? :to_token_payload
+        AuthToken.new payload: entity.to_token_payload
+      else
+        AuthToken.new payload: { sub: entity.id }
+      end
     end
 
     def entity

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -22,11 +22,8 @@ module Knock
     def entity
       @entity ||=
         if self.class.name == "Knock::AuthTokenController"
-          warn <<-WARNING
-            [DEPRECATION]: Routing to `AuthTokenController` directly is deprecated.
-            Please use `<Entity Name>TokenController` inheriting from it instead.
-            E.g. `UserTokenController`
-          WARNING
+          warn "[DEPRECATION]: Routing to `AuthTokenController` directly is deprecated. Please use `<Entity Name>TokenController` inheriting from it instead. E.g. `UserTokenController`"
+          warn "[DEPRECATION]: Relying on `Knock.current_user_from_handle` is deprecated. Please implement `User#find_for_token_creation` instead."
           Knock.current_user_from_handle.call auth_params[Knock.handle_attr]
         else
           if entity_class.respond_to? :find_for_token_creation

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -5,7 +5,7 @@ module Knock
     before_action :authenticate!
 
     def create
-      render json: { jwt: auth_token.token }, status: :created
+      render json: auth_token, status: :created
     end
 
   private

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -27,7 +27,7 @@ module Knock
           Knock.current_user_from_handle.call auth_params[Knock.handle_attr]
         else
           if entity_class.respond_to? :find_for_token_creation
-            entity_class.find_for_token_creation auth_params
+            entity_class.find_for_token_creation request
           else
             entity_class.find_by email: auth_params[:email]
           end

--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -27,11 +27,11 @@ module Knock
       @entity ||=
         if self.class.name == "Knock::AuthTokenController"
           warn "[DEPRECATION]: Routing to `AuthTokenController` directly is deprecated. Please use `<Entity Name>TokenController` inheriting from it instead. E.g. `UserTokenController`"
-          warn "[DEPRECATION]: Relying on `Knock.current_user_from_handle` is deprecated. Please implement `User#find_for_token_creation` instead."
+          warn "[DEPRECATION]: Relying on `Knock.current_user_from_handle` is deprecated. Please implement `User#from_token_request` instead."
           Knock.current_user_from_handle.call auth_params[Knock.handle_attr]
         else
-          if entity_class.respond_to? :find_for_token_creation
-            entity_class.find_for_token_creation request
+          if entity_class.respond_to? :from_token_request
+            entity_class.from_token_request request
           else
             entity_class.find_by email: auth_params[:email]
           end

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -22,10 +22,7 @@ module Knock
         entity_class.find_for_authentication @payload
       else
         if entity_class.to_s == "User" && Knock.respond_to?(:current_user_from_token)
-          warn <<-WARNING
-            [DEPRECATION]: `Knock.current_user_from_token` is deprecated. Please
-            implement `User.find_for_authentication` instead.
-          WARNING
+          warn "[DEPRECATION]: `Knock.current_user_from_token` is deprecated. Please implement `User.find_for_authentication` instead."
           Knock.current_user_from_token.call @payload
         else
           entity_class.find @payload['sub']

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -17,8 +17,20 @@ module Knock
       end
     end
 
-    def current_user
-      @current_user ||= Knock.current_user_from_token.call @payload
+    def entity_for entity_class
+      if entity_class.respond_to? :find_for_authentication
+        entity_class.find_for_authentication @payload
+      else
+        if entity_class.to_s == "User" && Knock.respond_to?(:current_user_from_token)
+          warn <<-WARNING
+            [DEPRECATION]: `Knock.current_user_from_token` is deprecated. Please
+            implement `User.find_for_authentication` instead.
+          WARNING
+          Knock.current_user_from_token.call @payload
+        else
+          entity_class.find @payload['sub']
+        end
+      end
     end
 
   private

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -33,6 +33,10 @@ module Knock
       end
     end
 
+    def to_json options = {}
+      {jwt: @token}.to_json
+    end
+
   private
     def secret_key
       Knock.token_secret_signature_key.call

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -18,11 +18,11 @@ module Knock
     end
 
     def entity_for entity_class
-      if entity_class.respond_to? :find_for_authentication
-        entity_class.find_for_authentication @payload
+      if entity_class.respond_to? :from_token_payload
+        entity_class.from_token_payload @payload
       else
         if entity_class.to_s == "User" && Knock.respond_to?(:current_user_from_token)
-          warn "[DEPRECATION]: `Knock.current_user_from_token` is deprecated. Please implement `User.find_for_authentication` instead."
+          warn "[DEPRECATION]: `Knock.current_user_from_token` is deprecated. Please implement `User.from_token_payload` instead."
           Knock.current_user_from_token.call @payload
         else
           entity_class.find @payload['sub']

--- a/lib/generators/knock/token_controller_generator.rb
+++ b/lib/generators/knock/token_controller_generator.rb
@@ -1,0 +1,25 @@
+module Knock
+  class TokenControllerGenerator < Rails::Generators::Base
+    source_root File.expand_path("../../templates", __FILE__)
+    argument :name, type: :string
+
+    desc <<-DESC
+      Creates a Knock token controller for the given entity
+      and add the corresponding routes.
+    DESC
+
+    def copy_controller_file
+      template 'entity_token_controller.rb.erb', "app/controllers/#{name.underscore}_token_controller.rb"
+    end
+
+    def add_route
+      route "post '#{name.underscore}_token' => '#{name.underscore}_token#create'"
+    end
+
+    private
+
+    def entity_name
+      name
+    end
+  end
+end

--- a/lib/generators/templates/entity_token_controller.rb.erb
+++ b/lib/generators/templates/entity_token_controller.rb.erb
@@ -1,0 +1,2 @@
+class <%= entity_name.camelize %>TokenController < Knock::AuthTokenController
+end

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -1,5 +1,8 @@
 Knock.setup do |config|
 
+  ## [DEPRECATED]
+  ## This is deprecated in favor of `User.find_for_token_creation`.
+  ##
   ## User handle attribute
   ## ---------------------
   ##
@@ -8,6 +11,9 @@ Knock.setup do |config|
   ## Default:
   # config.handle_attr = :email
 
+  ## [DEPRECATED]
+  ## This is deprecated in favor of `User.find_for_token_creation`.
+  ##
   ## Current user retrieval from handle when signing in
   ## --------------------------------------------------
   ##
@@ -26,7 +32,7 @@ Knock.setup do |config|
   # config.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
 
   ## [DEPRECATED]
-  ## This variable is deprecated. Implement `User.find_for_authentication` instead.
+  ## This is depreacted in favor of `User.find_for_authentication`.
   ##
   ## Current user retrieval when validating token
   ## --------------------------------------------

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -25,6 +25,9 @@ Knock.setup do |config|
   ## Default:
   # config.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
 
+  ## [DEPRECATED]
+  ## This variable is deprecated. Implement `User.find_for_authentication` instead.
+  ##
   ## Current user retrieval when validating token
   ## --------------------------------------------
   ##

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -1,7 +1,7 @@
 Knock.setup do |config|
 
   ## [DEPRECATED]
-  ## This is deprecated in favor of `User.find_for_token_creation`.
+  ## This is deprecated in favor of `User.from_token_request`.
   ##
   ## User handle attribute
   ## ---------------------
@@ -12,7 +12,7 @@ Knock.setup do |config|
   # config.handle_attr = :email
 
   ## [DEPRECATED]
-  ## This is deprecated in favor of `User.find_for_token_creation`.
+  ## This is deprecated in favor of `User.from_token_request`.
   ##
   ## Current user retrieval from handle when signing in
   ## --------------------------------------------------
@@ -32,7 +32,7 @@ Knock.setup do |config|
   # config.current_user_from_handle = -> (handle) { User.find_by! Knock.handle_attr => handle }
 
   ## [DEPRECATED]
-  ## This is depreacted in favor of `User.find_for_authentication`.
+  ## This is depreacted in favor of `User.from_token_payload`.
   ##
   ## Current user retrieval when validating token
   ## --------------------------------------------

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -101,8 +101,7 @@ Knock.setup do |config|
   ## Exception Class
   ## ---------------
   ##
-  ## Configure the Exception to be used (raised and rescued) for User Not Found.
-  ## note: change this if ActiveRecord is not being used.
+  ## Configure the exception to be used when user cannot be found.
   ##
   ## Default:
   # config.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,14 +1,60 @@
 module Knock::Authenticable
-  def current_user
-    @current_user ||= begin
-      token = params[:token] || request.headers['Authorization'].split.last
-      Knock::AuthToken.new(token: token).current_user
+  def authenticate
+    warn <<-WARNING
+      [DEPRECATION]: `authenticate` is deprecated. Please use
+      `authenticate_user` instead.
+    WARNING
+    head(:unauthorized) unless authenticate_for(User)
+  end
+
+  def authenticate_for entity_class
+    token = params[:token] || token_from_request_headers
+    return nil if token.nil?
+
+    begin
+      @entity = Knock::AuthToken.new(token: token).entity_for(entity_class)
+      define_current_entity_getter(entity_class)
+      @entity
     rescue
       nil
     end
   end
 
-  def authenticate
-    head :unauthorized unless current_user
+  private
+
+  def method_missing(method, *args)
+    prefix, *parts = method.to_s.split('_')
+    case prefix
+    when 'authenticate'
+      entity_class = constant_from_parts(parts)
+      head(:unauthorized) unless send(:authenticate_for, entity_class)
+    when 'current'
+      entity_class = constant_from_parts(parts)
+      send(:authenticate_for, entity_class)
+    else
+      super
+    end
+  end
+
+  def token_from_request_headers
+    unless request.headers['Authorization'].nil?
+      request.headers['Authorization'].split.last
+    end
+  end
+
+  def define_current_entity_getter entity_class
+    getter_name = "current_#{entity_class.to_s.underscore}"
+    unless self.respond_to?(getter_name)
+      self.class.send(:define_method, getter_name) do
+        @entity ||= nil
+      end
+    end
+  end
+
+  # Not rescuing from NameError on purpose.
+  # If trying to use `authenticate_user` but no `User` constant exists,
+  # it makes more sense to raise NameError than NoMethodError.
+  def constant_from_parts parts
+    parts.map(&:capitalize).join.constantize
   end
 end

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,9 +1,6 @@
 module Knock::Authenticable
   def authenticate
-    warn <<-WARNING
-      [DEPRECATION]: `authenticate` is deprecated. Please use
-      `authenticate_user` instead.
-    WARNING
+    warn "[DEPRECATION]: `authenticate` is deprecated. Please use `authenticate_user` instead."
     head(:unauthorized) unless authenticate_for(User)
   end
 

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -20,7 +20,7 @@ module Knock::Authenticable
   private
 
   def method_missing(method, *args)
-    prefix, entity_name = method.to_s.split('_')
+    prefix, entity_name = method.to_s.split('_', 2)
     case prefix
     when 'authenticate'
       head(:unauthorized) unless authenticate_entity(entity_name)

--- a/test/controllers/knock/auth_token_controller_test.rb
+++ b/test/controllers/knock/auth_token_controller_test.rb
@@ -28,5 +28,12 @@ module Knock
       post :create, auth: { email: user.email, password: 'secret' }
       assert_response :created
     end
+
+    test "response contains token" do
+      post :create, auth: { email: user.email, password: 'secret' }
+
+      content = JSON.parse(response.body)
+      assert_equal true, content.has_key?("jwt")
+    end
   end
 end

--- a/test/dummy/app/controllers/admin_protected_controller.rb
+++ b/test/dummy/app/controllers/admin_protected_controller.rb
@@ -1,0 +1,7 @@
+class AdminProtectedController < ApplicationController
+  before_action :authenticate_admin
+
+  def index
+    head :ok
+  end
+end

--- a/test/dummy/app/controllers/admin_token_controller.rb
+++ b/test/dummy/app/controllers/admin_token_controller.rb
@@ -1,0 +1,2 @@
+class AdminTokenController < Knock::AuthTokenController
+end

--- a/test/dummy/app/controllers/composite_name_entity_protected_controller.rb
+++ b/test/dummy/app/controllers/composite_name_entity_protected_controller.rb
@@ -1,0 +1,7 @@
+class CompositeNameEntityProtectedController < ApplicationController
+  before_action :authenticate_composite_name_entity
+
+  def index
+    head :ok
+  end
+end

--- a/test/dummy/app/controllers/vendor_protected_controller.rb
+++ b/test/dummy/app/controllers/vendor_protected_controller.rb
@@ -1,0 +1,11 @@
+class VendorProtectedController < ApplicationController
+  before_action :authenticate_vendor, only: [:index]
+  before_action :some_missing_method, only: [:show]
+
+  def index
+    head :ok
+  end
+
+  def show
+  end
+end

--- a/test/dummy/app/controllers/vendor_token_controller.rb
+++ b/test/dummy/app/controllers/vendor_token_controller.rb
@@ -1,0 +1,2 @@
+class VendorTokenController < Knock::AuthTokenController
+end

--- a/test/dummy/app/models/admin.rb
+++ b/test/dummy/app/models/admin.rb
@@ -1,0 +1,3 @@
+class Admin < ActiveRecord::Base
+  has_secure_password
+end

--- a/test/dummy/app/models/admin.rb
+++ b/test/dummy/app/models/admin.rb
@@ -9,4 +9,8 @@ class Admin < ActiveRecord::Base
   def self.find_for_authentication payload
     self.find payload["sub"]
   end
+
+  def to_token_payload
+    {sub: id}
+  end
 end

--- a/test/dummy/app/models/admin.rb
+++ b/test/dummy/app/models/admin.rb
@@ -1,3 +1,12 @@
 class Admin < ActiveRecord::Base
   has_secure_password
+
+  def self.find_for_token_creation request
+    params = request.params["auth"]
+    self.find_by email: params["email"]
+  end
+
+  def self.find_for_authentication payload
+    self.find payload["sub"]
+  end
 end

--- a/test/dummy/app/models/admin.rb
+++ b/test/dummy/app/models/admin.rb
@@ -1,12 +1,12 @@
 class Admin < ActiveRecord::Base
   has_secure_password
 
-  def self.find_for_token_creation request
-    params = request.params["auth"]
-    self.find_by email: params["email"]
+  def self.from_token_request request
+    email = request.params["auth"] && request.params["auth"]["email"]
+    self.find_by email: email
   end
 
-  def self.find_for_authentication payload
+  def self.from_token_payload payload
     self.find payload["sub"]
   end
 

--- a/test/dummy/app/models/composite_name_entity.rb
+++ b/test/dummy/app/models/composite_name_entity.rb
@@ -1,0 +1,3 @@
+class CompositeNameEntity < ActiveRecord::Base
+  has_secure_password
+end

--- a/test/dummy/app/models/vendor.rb
+++ b/test/dummy/app/models/vendor.rb
@@ -1,0 +1,3 @@
+class Vendor < ActiveRecord::Base
+  has_secure_password
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
+  post 'admin_token' => 'admin_token#create'
+  post 'vendor_token' => 'vendor_token#create'
+
   resources :protected_resources
   resource :current_user
 
   resources :admin_protected
-
-  post 'admin_token' => 'admin_token#create'
+  resources :vendor_protected
 
   mount Knock::Engine => "/knock"
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resource :current_user
 
   resources :admin_protected
+  resources :composite_name_entity_protected
   resources :vendor_protected
 
   mount Knock::Engine => "/knock"

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   resources :protected_resources
   resource :current_user
+
+  resources :admin_protected
+
   mount Knock::Engine => "/knock"
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
 
   resources :admin_protected
 
+  post 'admin_token' => 'admin_token#create'
+
   mount Knock::Engine => "/knock"
 end

--- a/test/dummy/db/migrate/20160519075733_create_admins.rb
+++ b/test/dummy/db/migrate/20160519075733_create_admins.rb
@@ -1,0 +1,10 @@
+class CreateAdmins < ActiveRecord::Migration
+  def change
+    create_table :admins do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/migrate/20160522051816_create_vendors.rb
+++ b/test/dummy/db/migrate/20160522051816_create_vendors.rb
@@ -1,0 +1,10 @@
+class CreateVendors < ActiveRecord::Migration
+  def change
+    create_table :vendors do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/migrate/20160522181712_create_composite_name_entities.rb
+++ b/test/dummy/db/migrate/20160522181712_create_composite_name_entities.rb
@@ -1,0 +1,10 @@
+class CreateCompositeNameEntities < ActiveRecord::Migration
+  def change
+    create_table :composite_name_entities do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,9 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160522051816) do
+ActiveRecord::Schema.define(version: 20160522181712) do
 
   create_table "admins", force: :cascade do |t|
+    t.string   "email"
+    t.string   "password_digest"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  create_table "composite_name_entities", force: :cascade do |t|
     t.string   "email"
     t.string   "password_digest"
     t.datetime "created_at",      null: false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713101607) do
+ActiveRecord::Schema.define(version: 20160519075733) do
+
+  create_table "admins", force: :cascade do |t|
+    t.string   "email"
+    t.string   "password_digest"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",           null: false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160519075733) do
+ActiveRecord::Schema.define(version: 20160522051816) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "email"
@@ -23,6 +23,13 @@ ActiveRecord::Schema.define(version: 20160519075733) do
   create_table "users", force: :cascade do |t|
     t.string   "email",           null: false
     t.string   "password_digest", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  create_table "vendors", force: :cascade do |t|
+    t.string   "email"
+    t.string   "password_digest"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
   end

--- a/test/dummy/test/controllers/admin_protected_controller_test.rb
+++ b/test/dummy/test/controllers/admin_protected_controller_test.rb
@@ -12,7 +12,7 @@ class AdminProtectedControllerTest < ActionController::TestCase
     @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
   end
 
-  def invalid_resource_auth
+  def invalid_entity_auth
     @token = Knock::AuthToken.new(payload: { sub: 0 }).token
     @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
   end
@@ -28,8 +28,8 @@ class AdminProtectedControllerTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
-  test "responds with unauthorized to invalid resource" do
-    invalid_resource_auth
+  test "responds with unauthorized to invalid entity" do
+    invalid_entity_auth
     get :index
     assert_response :unauthorized
   end

--- a/test/dummy/test/controllers/admin_protected_controller_test.rb
+++ b/test/dummy/test/controllers/admin_protected_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class AdminProtectedControllerTest < ActionController::TestCase
+  def valid_auth
+    @admin = admins(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @admin.id }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_token_auth
+    @token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_resource_auth
+    @token = Knock::AuthToken.new(payload: { sub: 0 }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  test "responds with unauthorized" do
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid token" do
+    invalid_token_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid resource" do
+    invalid_resource_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with success if authenticated" do
+    valid_auth
+    get :index
+    assert_response :success
+  end
+
+  test "has a current_admin after authentication" do
+    valid_auth
+    get :index
+    assert_response :success
+    assert @controller.current_admin.id == @admin.id
+  end
+end

--- a/test/dummy/test/controllers/admin_token_controller_test.rb
+++ b/test/dummy/test/controllers/admin_token_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class AdminTokenControllerTest < ActionController::TestCase
+  def setup
+    @admin = admins(:one)
+  end
+
+  test "responds with 404 if user does not exist" do
+    post :create, auth: { email: 'wrong@example.net', password: '' }
+    assert_response :not_found
+  end
+
+  test "responds with 404 if password is invalid" do
+    post :create, auth: { email: @admin.email, password: 'wrong' }
+    assert_response :not_found
+  end
+
+  test "responds with 201" do
+    post :create, auth: { email: @admin.email, password: 'secret' }
+    assert_response :created
+  end
+end

--- a/test/dummy/test/controllers/composite_name_entity_protected_controller_test.rb
+++ b/test/dummy/test/controllers/composite_name_entity_protected_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class CompositeNameEntityProtectedControllerTest < ActionController::TestCase
+  def valid_auth
+    @composite_name_entity = composite_name_entities(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @composite_name_entity.id }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_token_auth
+    @token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_entity_auth
+    @token = Knock::AuthToken.new(payload: { sub: 0 }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  test "responds with unauthorized" do
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid token" do
+    invalid_token_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid entity" do
+    invalid_entity_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with success if authenticated" do
+    valid_auth
+    get :index
+    assert_response :success
+  end
+
+  test "has a current_composite_name_entity after authentication" do
+    valid_auth
+    get :index
+    assert_response :success
+    assert @controller.current_composite_name_entity.id == @composite_name_entity.id
+  end
+end

--- a/test/dummy/test/controllers/vendor_protected_controller_test.rb
+++ b/test/dummy/test/controllers/vendor_protected_controller_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class VendorProtectedControllerTest < ActionController::TestCase
+  def valid_auth
+    @vendor = vendors(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @vendor.id }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_token_auth
+    @token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_entity_auth
+    @token = Knock::AuthToken.new(payload: { sub: 0 }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  test "responds with unauthorized" do
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid token" do
+    invalid_token_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid entity" do
+    invalid_entity_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with success if authenticated" do
+    valid_auth
+    get :index
+    assert_response :success
+  end
+
+  test "has a current_vendor after authentication" do
+    valid_auth
+    get :index
+    assert_response :success
+    assert @controller.current_vendor.id == @vendor.id
+  end
+
+  test "raises method missing error appropriately" do
+    assert_raises(NoMethodError) do
+      get :show, id: 1
+    end
+  end
+end

--- a/test/dummy/test/controllers/vendor_token_controller_test.rb
+++ b/test/dummy/test/controllers/vendor_token_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class VendorTokenControllerTest < ActionController::TestCase
+  def setup
+    @vendor = vendors(:one)
+  end
+
+  test "responds with 404 if user does not exist" do
+    post :create, auth: { email: 'wrong@example.net', password: '' }
+    assert_response :not_found
+  end
+
+  test "responds with 404 if password is invalid" do
+    post :create, auth: { email: @vendor.email, password: 'wrong' }
+    assert_response :not_found
+  end
+
+  test "responds with 201" do
+    post :create, auth: { email: @vendor.email, password: 'secret' }
+    assert_response :created
+  end
+end

--- a/test/dummy/test/fixtures/admins.yml
+++ b/test/dummy/test/fixtures/admins.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: MyString
+  password_digest: MyString
+
+two:
+  email: MyString
+  password_digest: MyString

--- a/test/dummy/test/fixtures/admins.yml
+++ b/test/dummy/test/fixtures/admins.yml
@@ -1,9 +1,0 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  email: MyString
-  password_digest: MyString
-
-two:
-  email: MyString
-  password_digest: MyString

--- a/test/dummy/test/models/admin_test.rb
+++ b/test/dummy/test/models/admin_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/dummy/test/models/vendor_test.rb
+++ b/test/dummy/test/models/vendor_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class VendorTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: admin.one@example.net
+  password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>

--- a/test/fixtures/composite_name_entities.yml
+++ b/test/fixtures/composite_name_entities.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: admin.one@example.net
+  password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>

--- a/test/fixtures/composite_name_entities.yml
+++ b/test/fixtures/composite_name_entities.yml
@@ -1,5 +1,5 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  email: admin.one@example.net
+  email: composite_name_entity.one@example.net
   password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>

--- a/test/fixtures/vendors.yml
+++ b/test/fixtures/vendors.yml
@@ -1,9 +1,5 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  email: one@example.net
-  password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>
-
-two:
-  email: two@example.net
+  email: vendor.one@example.net
   password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>

--- a/test/generators/token_controller_generator_test.rb
+++ b/test/generators/token_controller_generator_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class TokenControllerGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+
+  tests Knock::TokenControllerGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+
+  setup :prepare_destination
+  setup :copy_routes
+
+  test "assert all files are properly created" do
+    run_generator ['User']
+    assert_file "app/controllers/user_token_controller.rb"
+
+    run_generator ['Admin']
+    assert_file "app/controllers/user_token_controller.rb"
+
+    run_generator ['AdminUser']
+    assert_file "app/controllers/admin_user_token_controller.rb"
+
+    require File.join(destination_root, "app/controllers/admin_user_token_controller.rb")
+    assert Object.const_defined?('AdminUserTokenController'), 'uninitialized constant AdminUserTokenController'
+
+    run_generator ['user_admin']
+    assert_file "app/controllers/user_admin_token_controller.rb"
+
+    require File.join(destination_root, "app/controllers/user_admin_token_controller.rb")
+    assert Object.const_defined?('UserAdminTokenController'), 'uninitialized constant UserAdminTokenController'
+  end
+end

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -4,24 +4,25 @@ require 'timecop'
 
 module Knock
   class AuthTokenTest < ActiveSupport::TestCase
+    setup do
+      key = Knock.token_secret_signature_key.call
+      @token = JWT.encode({sub: '1'}, key, 'HS256')
+    end
+
     test "verify algorithm" do
       Knock.token_signature_algorithm = 'RS256'
-      key = Knock.token_secret_signature_key.call
-
-      token = JWT.encode({sub: '1'}, key, 'HS256')
 
       assert_raises(JWT::IncorrectAlgorithm) {
-        AuthToken.new(token: token)
+        AuthToken.new(token: @token)
       }
     end
 
     test "decode RSA encoded tokens" do
-      user = users(:one)
       rsa_private = OpenSSL::PKey::RSA.generate 2048
       Knock.token_public_key = rsa_private.public_key
       Knock.token_signature_algorithm = 'RS256'
 
-      token = JWT.encode({sub: user.id}, rsa_private, 'RS256')
+      token = JWT.encode({sub: "1"}, rsa_private, 'RS256')
 
       assert_nothing_raised { AuthToken.new(token: token) }
     end
@@ -42,10 +43,8 @@ module Knock
       Knock.token_audience = -> { 'bar' }
       key = Knock.token_secret_signature_key.call
 
-      token = JWT.encode({sub: 'foo'}, key, 'HS256')
-
       assert_raises(JWT::InvalidAudError) {
-        AuthToken.new token: token
+        AuthToken.new token: @token
       }
     end
 
@@ -65,6 +64,12 @@ module Knock
       Timecop.travel(10.years.from_now) do
         assert_not Knock::AuthToken.new(token: token).payload.has_key?('exp')
       end
+    end
+
+    test "is serializable" do
+      auth_token = AuthToken.new token: @token
+
+      assert_equal("{\"jwt\":\"#{@token}\"}", auth_token.to_json)
     end
   end
 end

--- a/test/support/generators_test_helper.rb
+++ b/test/support/generators_test_helper.rb
@@ -1,0 +1,9 @@
+module GeneratorsTestHelper
+  def copy_routes
+    routes = File.expand_path("../../dummy/config/routes.rb", __FILE__)
+    destination = File.join(destination_root, "config")
+
+    FileUtils.mkdir_p(destination)
+    FileUtils.cp routes, destination
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,7 @@
+require 'simplecov'
 require "codeclimate-test-reporter"
+
+SimpleCov.start
 CodeClimate::TestReporter.start
 
 # Configure Rails Environment


### PR DESCRIPTION
### Context

I want to implement the features provided by the `v2` branch into `master` without introducing breaking changes. This way, the `v2` release will only consist of removing deprecated code.

Major improvements:

- Multiple entities authentication (User, Admin, etc)
- Customization via method implementation inside the entity model instead of initializer lambda configuration

### Implementation

- Automatically infer entity when authenticating. E.g. `authenticate_user` will try to authenticate via the `User` model.
- Automatically infer entity when creating token (sign in). E.g. Signing in via `UserTokenController` will try to create a token via the `User` model.
- Deprecate `Knock.current_user_from_token` in favor of `User.find_for_authentication`
- Deprecate `Knock.current_user_from_handle` in favor of `User.find_for_token_creation`