### PR TITLE
Fix for entities with composite names

### DIFF
--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -20,7 +20,7 @@ module Knock::Authenticable
   private
 
   def method_missing(method, *args)
-    prefix, entity_name = method.to_s.split('_')
+    prefix, entity_name = method.to_s.split('_', 2)
     case prefix
     when 'authenticate'
       head(:unauthorized) unless authenticate_entity(entity_name)

--- a/test/dummy/app/controllers/composite_name_entity_protected_controller.rb
+++ b/test/dummy/app/controllers/composite_name_entity_protected_controller.rb
@@ -1,0 +1,7 @@
+class CompositeNameEntityProtectedController < ApplicationController
+  before_action :authenticate_composite_name_entity
+
+  def index
+    head :ok
+  end
+end

--- a/test/dummy/app/models/composite_name_entity.rb
+++ b/test/dummy/app/models/composite_name_entity.rb
@@ -1,0 +1,3 @@
+class CompositeNameEntity < ActiveRecord::Base
+  has_secure_password
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resource :current_user
 
   resources :admin_protected
+  resources :composite_name_entity_protected
   resources :vendor_protected
 
   mount Knock::Engine => "/knock"

--- a/test/dummy/db/migrate/20160522181712_create_composite_name_entities.rb
+++ b/test/dummy/db/migrate/20160522181712_create_composite_name_entities.rb
@@ -1,0 +1,10 @@
+class CreateCompositeNameEntities < ActiveRecord::Migration
+  def change
+    create_table :composite_name_entities do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,9 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160522051816) do
+ActiveRecord::Schema.define(version: 20160522181712) do
 
   create_table "admins", force: :cascade do |t|
+    t.string   "email"
+    t.string   "password_digest"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  create_table "composite_name_entities", force: :cascade do |t|
     t.string   "email"
     t.string   "password_digest"
     t.datetime "created_at",      null: false

--- a/test/dummy/test/controllers/composite_name_entity_protected_controller_test.rb
+++ b/test/dummy/test/controllers/composite_name_entity_protected_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class CompositeNameEntityProtectedControllerTest < ActionController::TestCase
+  def valid_auth
+    @composite_name_entity = composite_name_entities(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @composite_name_entity.id }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_token_auth
+    @token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_entity_auth
+    @token = Knock::AuthToken.new(payload: { sub: 0 }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  test "responds with unauthorized" do
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid token" do
+    invalid_token_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with unauthorized to invalid entity" do
+    invalid_entity_auth
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with success if authenticated" do
+    valid_auth
+    get :index
+    assert_response :success
+  end
+
+  test "has a current_composite_name_entity after authentication" do
+    valid_auth
+    get :index
+    assert_response :success
+    assert @controller.current_composite_name_entity.id == @composite_name_entity.id
+  end
+end

--- a/test/fixtures/composite_name_entities.yml
+++ b/test/fixtures/composite_name_entities.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: admin.one@example.net
+  password_digest: <%= BCrypt::Password.create('secret', cost: 4) %>


### PR DESCRIPTION
It should be `split('_', 2)` to split into only two substrings, allowing `camelize.constantize` to correctly get the entity name.

Just with `split('_')`, in case of  `authenticate_composite_name_entity`:
```ruby
prefix, entity_name = 'authenticate_composite_name_entity'.split('_')
```
`entity_name` will only contain `"composite"` value.