### PR TITLE
Add custom unauthorized entity

### DIFF
--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -23,7 +23,7 @@ module Knock::Authenticable
     prefix, entity_name = method.to_s.split('_', 2)
     case prefix
     when 'authenticate'
-      head(:unauthorized) unless authenticate_entity(entity_name)
+      unauthorized_entity(entity_name) unless authenticate_entity(entity_name)
     when 'current'
       authenticate_entity(entity_name)
     else
@@ -34,6 +34,10 @@ module Knock::Authenticable
   def authenticate_entity(entity_name)
     entity_class = entity_name.camelize.constantize
     send(:authenticate_for, entity_class)
+  end
+
+  def unauthorized_entity(entity_name)
+    head(:unauthorized)
   end
 
   def token_from_request_headers

--- a/test/dummy/app/controllers/custom_unauthorized_entity_controller.rb
+++ b/test/dummy/app/controllers/custom_unauthorized_entity_controller.rb
@@ -1,0 +1,13 @@
+class CustomUnauthorizedEntityController < ApplicationController
+  before_action :authenticate_user
+
+  def index
+    head :ok
+  end
+
+  private
+
+  def unauthorized_entity(entity)
+    head :not_found
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :admin_protected
   resources :composite_name_entity_protected
   resources :vendor_protected
+  resources :custom_unauthorized_entity
 
   mount Knock::Engine => "/knock"
 end

--- a/test/dummy/test/controllers/custom_unauthorized_entity_controller_test.rb
+++ b/test/dummy/test/controllers/custom_unauthorized_entity_controller_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class CustomUnauthorizedEntityControllerTest < ActionController::TestCase
+  def valid_auth
+    @user = users(:one)
+    @token = Knock::AuthToken.new(payload: { sub: @user.id }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_token_auth
+    @token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  def invalid_entity_auth
+    @token = Knock::AuthToken.new(payload: { sub: 0 }).token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{@token}"
+  end
+
+  test "responds with not found" do
+    get :index
+    assert_response :not_found
+  end
+
+  test "responds with not found to invalid token" do
+    invalid_token_auth
+    get :index
+    assert_response :not_found
+  end
+
+  test "responds with not found to invalid entity" do
+    invalid_entity_auth
+    get :index
+    assert_response :not_found
+  end
+
+  test "responds with success if authenticated" do
+    valid_auth
+    get :index
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Hi there,

Thanks for making this simple and awesome library that just fits very well into Rails APIs.
In my APIs, I always return a textual version of the error for user agents to render. Therefore I needed to be able to send a custom message with the unauthorized header.

This pull request enables us to override handling of the unauthorized entity and do the following:

```ruby
class ApplicationController < ActionController::API
  include Knock::Authenticable

  private

  def unauthorized_entity(entity_name)
    render json: ["Unauthorized"], status: :unauthorized
  end
end
```

Thanks in advance.
Lasse