### PR TITLE
Current user auth failing test case

### DIFF
--- a/test/dummy/test/controllers/current_users_controller_test.rb
+++ b/test/dummy/test/controllers/current_users_controller_test.rb
@@ -20,4 +20,10 @@ class CurrentUsersControllerTest < ActionController::TestCase
     get :show
     assert_response :success
   end
+
+  test "responds with 200 for the second time" do
+    authenticate
+    get :show
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Affected version: 1.5
The current user auth was working at 1.4.2.

