### PR TITLE
Fix failing test case reported by #82

### DIFF
--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -5,19 +5,16 @@ module Knock::Authenticable
   end
 
   def authenticate_for entity_class
-    token = params[:token] || token_from_request_headers
-    return nil if token.nil?
-
-    begin
-      @entity = Knock::AuthToken.new(token: token).entity_for(entity_class)
-      define_current_entity_getter(entity_class)
-      @entity
-    rescue
-      nil
-    end
+    getter_name = "current_#{entity_class.to_s.underscore}"
+    define_current_entity_getter(entity_class, getter_name)
+    public_send(getter_name)
   end
 
   private
+
+  def token
+    params[:token] || token_from_request_headers
+  end
 
   def method_missing(method, *args)
     prefix, entity_name = method.to_s.split('_', 2)
@@ -42,11 +39,20 @@ module Knock::Authenticable
     end
   end
 
-  def define_current_entity_getter entity_class
-    getter_name = "current_#{entity_class.to_s.underscore}"
+  def define_current_entity_getter entity_class, getter_name
     unless self.respond_to?(getter_name)
+      memoization_var_name = "@_#{getter_name}"
       self.class.send(:define_method, getter_name) do
-        @entity ||= nil
+        unless instance_variable_defined?(memoization_var_name)
+          current =
+            begin
+              Knock::AuthToken.new(token: token).entity_for(entity_class)
+            rescue
+              nil
+            end
+          instance_variable_set(memoization_var_name, current)
+        end
+        instance_variable_get(memoization_var_name)
       end
     end
   end

--- a/test/dummy/test/controllers/current_users_controller_test.rb
+++ b/test/dummy/test/controllers/current_users_controller_test.rb
@@ -20,4 +20,12 @@ class CurrentUsersControllerTest < ActionController::TestCase
     get :show
     assert_response :success
   end
+
+  # Run this test twice to validate that it still works
+  # when the getter method has already been defined.
+  test "responds with 200 #2" do
+    authenticate
+    get :show
+    assert_response :success
+  end
 end


### PR DESCRIPTION
### Context

@l4u created a failing test case in #82. The test fails if you run it twice because of the getter method being already dynamically defined but the `@entity` instance being `nil`.

### Action

- [x] Rewrite the `Authenticable#authenticate_for` method to make the implementation less fragile

### Discussion

I kept the duplicate test to avoid regression in the future, although I believe this shouldn't happen in the first place as tests shouldn't be affecting one another. Open to suggestions on how this could be done better.

Merging this PR should close #82.