### PR TITLE
add config to allow customizing the current user helper method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - unreleased
 ### Added
 - Configurable unauthorized response by overriding `Authenticable#unauthorized_entity`
+- Configurable current user prefix
 
 ## [1.5] - 2016-05-29
 ### Added

--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -105,4 +105,12 @@ Knock.setup do |config|
   ##
   ## Default:
   # config.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'
+
+  ## Current User prefix
+  ## -------------------
+  ##
+  ## Configure the prefix of the current user helper method.
+  ##
+  ## Default:
+  ## config.current_user_prefix = 'current'
 end

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -5,6 +5,9 @@ module Knock
   mattr_accessor :handle_attr
   self.handle_attr = :email
 
+  mattr_accessor :current_user_prefix
+  self.current_user_prefix = 'current'
+
   mattr_accessor :current_user_from_handle
   self.current_user_from_handle = -> handle { User.find_by! Knock.handle_attr => handle }
 

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -5,7 +5,7 @@ module Knock::Authenticable
   end
 
   def authenticate_for entity_class
-    getter_name = "current_#{entity_class.to_s.underscore}"
+    getter_name = "#{Knock.current_user_prefix}_#{entity_class.to_s.underscore}"
     define_current_entity_getter(entity_class, getter_name)
     public_send(getter_name)
   end

--- a/test/dummy/config/initializers/knock.rb
+++ b/test/dummy/config/initializers/knock.rb
@@ -3,6 +3,7 @@ Knock.setup do |config|
   config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
   config.token_public_key = nil
   config.token_audience = nil
+  config.current_user_prefix = "current_api"
 
   config.current_user_from_handle = -> handle { User.find_by(Knock.handle_attr => handle) || raise(Knock::MyCustomException) }
   config.current_user_from_token = -> claims { User.find_by(id: claims['sub']) || raise(Knock::MyCustomException) }

--- a/test/dummy/test/controllers/protected_resources_controller_test.rb
+++ b/test/dummy/test/controllers/protected_resources_controller_test.rb
@@ -44,6 +44,13 @@ class ProtectedResourcesControllerTest < ActionController::TestCase
     assert @controller.current_user.id == @user.id
   end
 
+  test "has a prefixed current user after authentication" do
+    authenticate
+    get :index
+    assert_response :success
+    assert @controller.current_api_user.id == @user.id
+  end
+
   test "accepts any prefix in the authorization header" do
     @request.env['HTTP_AUTHORIZATION'] = "Other #{@token}"
 


### PR DESCRIPTION
I added a config option to allow custom prefixing of the current user helper method. 
For example, the following will generate a `current_api_user` method.  
`config.current_user_prefix = 'current_api'`
