### PR TITLE
Added verify_options to AuthToken initializer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - unreleased
 ### Added
 - Configurable unauthorized response by overriding `Authenticable#unauthorized_entity`
+- Configurable default validations by adding verify_options to AuthToken initializer
 
 ## [1.5] - 2016-05-29
 ### Added

--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -5,9 +5,9 @@ module Knock
     attr_reader :token
     attr_reader :payload
 
-    def initialize payload: {}, token: nil
+    def initialize payload: {}, token: nil, verify_options: {}
       if token.present?
-        @payload, _ = JWT.decode token, decode_key, true, options
+        @payload, _ = JWT.decode token, decode_key, true, options.merge(verify_options)
         @token = token
       else
         @payload = payload


### PR DESCRIPTION
Allows more control on what gets validated, for situations where you want less validation than the default
