### PR TITLE
Allow having token_controller inside namespaces

### DIFF
--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -43,7 +43,7 @@ module Knock
     end
 
     def entity_name
-      self.class.name.split('TokenController').first
+      self.class.name.scan(/\w+/).last.split('TokenController').first
     end
 
     def auth_params

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
It doesn't take into account non-word characters from the controller name. For example,

```
class Api::V1::UserTokenController < Knock::AuthTokenController
end
```

With this patch, `entity_name` at `app/controllers/knock/auth_token_controller.rb` returns `User` instead `Api::V1::User`.
