### PR TITLE
Modify payload

### DIFF
--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -10,8 +10,8 @@ module Knock
         @payload, _ = JWT.decode token, decode_key, true, options
         @token = token
       else
-        @payload = payload
-        @token = JWT.encode claims.merge(payload),
+        @payload = claims.merge(payload)
+        @token = JWT.encode @payload,
           secret_key,
           Knock.token_signature_algorithm
       end

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -66,6 +66,13 @@ module Knock
       end
     end
 
+    test "Knock::AuthToken has all payloads" do
+      Knock.token_lifetime = 7.days
+      payload = Knock::AuthToken.new(payload: { sub: 'foo' }).payload
+      assert payload.has_key?(:sub)
+      assert payload.has_key?(:exp)
+    end
+
     test "is serializable" do
       auth_token = AuthToken.new token: @token
 


### PR DESCRIPTION
When encode, Knock::AuthToken doesn't include `exp` in payload. But when decode, includes it.
I want all payloads without decode when generated token.
