### PR TITLE
Allow name spaced models

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ class SecuredController < ApplicationController
 end
 ```
 
+Then you get the current user by calling `current_v1_user` instead of `current_user`.
+
 ### Customization
 
 #### Via the entity model

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,6 +1,6 @@
 module Knock::Authenticable
   def authenticate_for entity_class
-    getter_name = "current_#{entity_class.to_s.underscore}"
+    getter_name = "current_#{entity_class.to_s.parameterize.underscore}"
     define_current_entity_getter(entity_class, getter_name)
     public_send(getter_name)
   end


### PR DESCRIPTION
I get the following error when using namespaced model `Unsakini::User`. This is the fix I came up with.

     Failure/Error: authenticate_for Unsakini::User
     
     NameError:
       `@_current_unsakini/user' is not allowed as an instance variable name