### PR TITLE
Rails 5 forbids auto loading in production

### DIFF
--- a/lib/knock/engine.rb
+++ b/lib/knock/engine.rb
@@ -1,6 +1,6 @@
 module Knock
   class Engine < ::Rails::Engine
-    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
     isolate_namespace Knock
   end
 end


### PR DESCRIPTION
Rails 5 forbids auto loading in production because is not thread safe, instead we should use eager load, or move all the code under the app/ directory.