### PR TITLE
Rescue specific exceptions in Authenticable

### DIFF
--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -7,7 +7,7 @@ module Knock
 
     def initialize payload: {}, token: nil, verify_options: {}
       if token.present?
-        @payload, _ = JWT.decode token, decode_key, true, options.merge(verify_options)
+        @payload, _ = JWT.decode token.to_s, decode_key, true, options.merge(verify_options)
         @token = token
       else
         @payload = claims.merge(payload)

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -46,7 +46,7 @@ module Knock::Authenticable
           current =
             begin
               Knock::AuthToken.new(token: token).entity_for(entity_class)
-            rescue
+            rescue ActiveRecord::RecordNotFound
               nil
             end
           instance_variable_set(memoization_var_name, current)

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -46,7 +46,7 @@ module Knock::Authenticable
           current =
             begin
               Knock::AuthToken.new(token: token).entity_for(entity_class)
-            rescue ActiveRecord::RecordNotFound
+            rescue ActiveRecord::RecordNotFound, JWT::DecodeError
               nil
             end
           instance_variable_set(memoization_var_name, current)

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -46,7 +46,7 @@ module Knock::Authenticable
           current =
             begin
               Knock::AuthToken.new(token: token).entity_for(entity_class)
-            rescue ActiveRecord::RecordNotFound, JWT::DecodeError
+            rescue Knock.not_found_exception_class, JWT::DecodeError
               nil
             end
           instance_variable_set(memoization_var_name, current)

--- a/test/dummy/config/initializers/knock.rb
+++ b/test/dummy/config/initializers/knock.rb
@@ -4,5 +4,5 @@ Knock.setup do |config|
   config.token_public_key = nil
   config.token_audience = nil
 
-  config.not_found_exception_class_name = 'Knock::MyCustomException'
+  config.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'
 end


### PR DESCRIPTION
Currently, `Knock::Authenticable` rescues all exceptions when trying to decode the JWT and find the user. This is an anti-pattern: if, for whatever reason, either `.from_token_payload` or any other piece of the code in the `rescue` block fails for an unexpected reason, authentication will silently fail.

In the best-case scenario, this means that the developer is left to debug a confusing issue without the required context.

In the worst-case scenario, authentication fails and the developer does not know about it (it should be caught by tests, but not all applications are tested properly, as we all know).

This PR changes `Knock::Authenticable#define_current_entity_getter` to only rescue `ActiveRecord::RecordNotFound` and `JWT::DecodeError`, the two errors which should be handled. All other errors will crash the application, as one would expect.

I have run the existing test suite against the PR and it passes.