### PR TITLE
Check token presense before trying to look up entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1]
+## [2.1.1] - 2017-02-11
+### Fixed
+- Stop trying to retrieve user from empty payload when no token is given
+
+## [2.1] - 2017-01-31
 ### Fixed
 - Parsing of token controller to handle namespaces correctly
 

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -24,8 +24,10 @@ module Knock::Authenticable
   end
 
   def authenticate_entity(entity_name)
-    entity_class = entity_name.camelize.constantize
-    send(:authenticate_for, entity_class)
+    if token
+      entity_class = entity_name.camelize.constantize
+      send(:authenticate_for, entity_class)
+    end
   end
 
   def unauthorized_entity(entity_name)

--- a/lib/knock/version.rb
+++ b/lib/knock/version.rb
@@ -1,3 +1,3 @@
 module Knock
-  VERSION = "2.1"
+  VERSION = "2.1.1"
 end

--- a/test/dummy/app/controllers/guest_protected_controller.rb
+++ b/test/dummy/app/controllers/guest_protected_controller.rb
@@ -1,0 +1,7 @@
+class GuestProtectedController < ApplicationController
+  before_action :authenticate_guest
+
+  def index
+    head :ok
+  end
+end

--- a/test/dummy/app/models/guest.rb
+++ b/test/dummy/app/models/guest.rb
@@ -1,0 +1,7 @@
+class Guest
+  def self.from_token_payload _payload
+    # This is to simulate the use of `find_or_create`
+    # on an AR model, regardless of the payload content
+    new
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,13 +2,12 @@ Rails.application.routes.draw do
   post 'admin_token' => 'admin_token#create'
   post 'vendor_token' => 'vendor_token#create'
 
-  resources :protected_resources
   resource :current_user
 
   resources :admin_protected
   resources :composite_name_entity_protected
-  resources :vendor_protected
   resources :custom_unauthorized_entity
-
-  mount Knock::Engine => "/knock"
+  resources :guest_protected
+  resources :protected_resources
+  resources :vendor_protected
 end

--- a/test/dummy/test/controllers/guest_protected_controller_test.rb
+++ b/test/dummy/test/controllers/guest_protected_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class GuestProtectedControllerTest < ActionController::TestCase
+  def setup
+    @token = Knock::AuthToken.new(payload: { sub: "1" }).token
+  end
+
+  def authenticate token: @token
+    @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token}"
+  end
+
+  test "responds with unauthorized when no token is provided" do
+    get :index
+    assert_response :unauthorized
+  end
+
+  test "responds with success with a valid token in the header" do
+    authenticate
+    get :index
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### Background context

See issue #142 

### Proposed solution

This patch should ensure the token is present before trying to look up the user with `find` or via `from_token_payload`.

This should avoid any chance of a user being granted access due to the use of `find_or_create` with an empty payload.