### PR TITLE
Moving rails dependency as a dev one

### DIFF
--- a/knock.gemspec
+++ b/knock.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.2"
   s.add_dependency "jwt", "~> 1.5"
   s.add_dependency "bcrypt", "~> 3.1"
 
+  s.add_development_dependency "rails", ">= 4.2"
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency "timecop", "~> 0.8.0"
 end

--- a/lib/generators/knock/install_generator.rb
+++ b/lib/generators/knock/install_generator.rb
@@ -1,4 +1,4 @@
-require 'rails/generators/named_base'
+require 'rails/generators'
 
 module Knock
   class InstallGenerator < Rails::Generators::Base

--- a/lib/generators/knock/install_generator.rb
+++ b/lib/generators/knock/install_generator.rb
@@ -1,3 +1,5 @@
+require 'rails/generators/named_base'
+
 module Knock
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path("../../templates", __FILE__)

--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -1,59 +1,61 @@
-module Knock::Authenticable
-  def authenticate_for entity_class
-    getter_name = "current_#{entity_class.to_s.parameterize.underscore}"
-    define_current_entity_getter(entity_class, getter_name)
-    public_send(getter_name)
-  end
-
-  private
-
-  def token
-    params[:token] || token_from_request_headers
-  end
-
-  def method_missing(method, *args)
-    prefix, entity_name = method.to_s.split('_', 2)
-    case prefix
-    when 'authenticate'
-      unauthorized_entity(entity_name) unless authenticate_entity(entity_name)
-    when 'current'
-      authenticate_entity(entity_name)
-    else
-      super
+module Knock
+  class Authenticable
+    def authenticate_for entity_class
+      getter_name = "current_#{entity_class.to_s.parameterize.underscore}"
+      define_current_entity_getter(entity_class, getter_name)
+      public_send(getter_name)
     end
-  end
 
-  def authenticate_entity(entity_name)
-    if token
-      entity_class = entity_name.camelize.constantize
-      send(:authenticate_for, entity_class)
+    private
+
+    def token
+      params[:token] || token_from_request_headers
     end
-  end
 
-  def unauthorized_entity(entity_name)
-    head(:unauthorized)
-  end
-
-  def token_from_request_headers
-    unless request.headers['Authorization'].nil?
-      request.headers['Authorization'].split.last
+    def method_missing(method, *args)
+      prefix, entity_name = method.to_s.split('_', 2)
+      case prefix
+      when 'authenticate'
+        unauthorized_entity(entity_name) unless authenticate_entity(entity_name)
+      when 'current'
+        authenticate_entity(entity_name)
+      else
+        super
+      end
     end
-  end
 
-  def define_current_entity_getter entity_class, getter_name
-    unless self.respond_to?(getter_name)
-      memoization_var_name = "@_#{getter_name}"
-      self.class.send(:define_method, getter_name) do
-        unless instance_variable_defined?(memoization_var_name)
-          current =
-            begin
-              Knock::AuthToken.new(token: token).entity_for(entity_class)
-            rescue Knock.not_found_exception_class, JWT::DecodeError
-              nil
-            end
-          instance_variable_set(memoization_var_name, current)
+    def authenticate_entity(entity_name)
+      if token
+        entity_class = entity_name.camelize.constantize
+        send(:authenticate_for, entity_class)
+      end
+    end
+
+    def unauthorized_entity(entity_name)
+      head(:unauthorized)
+    end
+
+    def token_from_request_headers
+      unless request.headers['Authorization'].nil?
+        request.headers['Authorization'].split.last
+      end
+    end
+
+    def define_current_entity_getter entity_class, getter_name
+      unless self.respond_to?(getter_name)
+        memoization_var_name = "@_#{getter_name}"
+        self.class.send(:define_method, getter_name) do
+          unless instance_variable_defined?(memoization_var_name)
+            current =
+              begin
+                Knock::AuthToken.new(token: token).entity_for(entity_class)
+              rescue Knock.not_found_exception_class, JWT::DecodeError
+                nil
+              end
+            instance_variable_set(memoization_var_name, current)
+          end
+          instance_variable_get(memoization_var_name)
         end
-        instance_variable_get(memoization_var_name)
       end
     end
   end


### PR DESCRIPTION
There is no need to have a rails dependency, specially because it's requiring gems like we don't actually need on specific rails apps like APIs.

```
sprockets/railtie: 3.6641 MiB
      sprockets/rails/context: 2.1406 MiB
        action_view/helpers: 2.1406 MiB
          action_view/helpers/form_helper: 1.6328 MiB (Also required by: action_view/helpers/form_options_helper)
            action_view/helpers/form_tag_helper: 1.5547 MiB
              action_view/helpers/text_helper: 1.4219 MiB
                action_view/helpers/sanitize_helper: 1.4219 MiB
                  rails-html-sanitizer: 1.4219 MiB
                    loofah: 1.375 MiB
                      nokogiri: 1.1719 MiB
                        nokogiri/xml: 0.4063 MiB
                        nokogiri/html: 0.3672 MiB
      sprockets: 1.3672 MiB (Also required by: sprockets/rails/context, sprockets/rails/helper)
        sprockets/environment: 0.543 MiB
          sprockets/base: 0.5117 MiB (Also required by:
```