### PR TITLE
update README, example code how to configure a public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,12 @@ You can specify any of the algorithms supported by the
 [jwt](https://github.com/jwt/ruby-jwt) gem.
 
 If the algorithm you use requires a public key, you also need to set
-`token_public_key` in the initializer.
+`token_public_key` in the initializer:
+```
+# example for RS256
+config.token_signature_algorithm = 'RS256'
+config.token_public_key = OpenSSL::PKey::RSA.new File.read(File.join(Rails.root, 'public_key.pem'))
+```
 
 ## CORS
 


### PR DESCRIPTION
In order to generate the `.pem` file I did the following:
```
pip install lokey
lokey fetch jwk your-auth0-client-domain.eu.auth0.com | lokey to pem > public_key.pem
```
Could have saved me a couple of hours if that would have been in the README.

I think it is also a viable alternative to #124, #123 and does not fire http requests like in #148 