### PR TITLE
Use ActionController::API for Knock::ApplicationController instead of ActionController::Base

### DIFF
--- a/app/controllers/knock/application_controller.rb
+++ b/app/controllers/knock/application_controller.rb
@@ -1,5 +1,5 @@
 module Knock
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ActionController::API
     rescue_from Knock.not_found_exception_class_name, with: :not_found
 
   private


### PR DESCRIPTION
Since this gem is for API-only Rails apps, this makes sense.  Using ActionController::Base might break things in an application that uses ActionController::API (mine included).