### PR TITLE
Test case for namespaced model

### DIFF
--- a/test/dummy/test/controllers/v1/test_namespaced_controller_test.rb
+++ b/test/dummy/test/controllers/v1/test_namespaced_controller_test.rb
@@ -15,5 +15,11 @@ module Knock
       assert_equal @user, @controller.current_v1_user
     end
 
+    test "disallow namespaced models with no payload" do
+      token = Knock::AuthToken.new(payload: { sub: @user.id }).token
+      get v1_test_namespaced_index_url
+      assert_response :unauthorized
+      assert_equal @user, @controller.current_v1_user
+    end
   end
 end


### PR DESCRIPTION
Instead of just opening an issue reporting the bug, I'm sending the code to the case I'm discussing on.

Controller is expected to return unauthorized for namespaced model
(specially in this case where even the key is being passed), but is
returns ok.

I'm tried to implement a solution, but I've just discovered knock last week, so I'm reporting this bug hope it helps someone else.

Thank you!