### PR TITLE
Issue-150 Namespaced Models Cause Uninitialized Constant Error

### DIFF
--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -37,7 +37,10 @@ module Knock
     end
 
     def entity_name
-      self.class.name.scan(/\w+/).last.split('TokenController').first
+      class_name = self.class.name
+      namespace = class_name.deconstantize
+      model_name = class_name.scan(/\w+/).last.split('TokenController').first
+      "#{namespace}#{'::' if namespace.present?}#{model_name}"
     end
 
     def auth_params


### PR DESCRIPTION
* Issue #150 explains the issue of having namespaced models. When the method entity name is called and the controller name is truncated to match the entity it does not include the namespace if there is one. This commit aims to fix that issue.