### PR TITLE
Unauthorized access on namespaced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ _Note: the `authenticate_user` method uses the `current_user` method. Overwritin
 
 You can do the exact same thing for any entity. E.g. for `Admin`, use `authenticate_admin` and `current_admin` instead.
 
-If you're using a namespaced model, Knock won't be able to infer it automatically from the method name. Instead you can use `authenticate_for` directly like this:
+If you're using a namespaced model, Knock won't be able to infer it automatically from the method name. Instead you can use the public API directly like this:
 
 ```ruby
 class ApplicationController < ActionController::Base
   include Knock::Authenticable
-    
+
   private
-  
-  def authenticate_v1_user
-    authenticate_for V1::User
+
+  def check_authentication!
+    unauthorized_entity('v1/user') unless authenticate_entity('v1/user')
   end
 end
 ```

--- a/test/dummy/app/controllers/v1/test_namespaced_controller.rb
+++ b/test/dummy/app/controllers/v1/test_namespaced_controller.rb
@@ -1,7 +1,7 @@
 module V1
   class TestNamespacedController < ApplicationController
 
-    before_action :authenticate_v1_user
+    before_action :check_authentication!
 
     def index
       head :ok
@@ -9,8 +9,8 @@ module V1
 
     private
 
-    def authenticate_v1_user
-      authenticate_for V1::User
+    def check_authentication!
+      unauthorized_entity('v1/user') unless authenticate_entity('v1/user')
     end
 
   end

--- a/test/dummy/test/controllers/v1/test_namespaced_controller_test.rb
+++ b/test/dummy/test/controllers/v1/test_namespaced_controller_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-# require 'timecop'
 
 module Knock
   class TestNamespacedControllerTest < ActionDispatch::IntegrationTest
@@ -13,6 +12,12 @@ module Knock
       get v1_test_namespaced_index_url, headers: {'Authorization': "Bearer #{token}"}
       assert_response :ok
       assert_equal @user, @controller.current_v1_user
+    end
+
+    test "deny namespaced models with bad token" do
+      get v1_test_namespaced_index_url, headers: {}
+      assert_response :unauthorized
+      assert_equal nil, @controller.current_v1_user
     end
 
   end


### PR DESCRIPTION
The examples in #126 do not cover unauthorized access to a Knock controller (basically Knock won't protect your endpoints if you follow the current instructions).

I suggest replacing those with the available API methods. Alternatively, I'm open to other suggestions.
I spent some time figuring out why the readme instructions do not work, it would be great if other developers do not hit the same issue.

Thanks in advance for taking a look.