### PR TITLE
Inherit from ActionController::API

### DIFF
--- a/app/controllers/knock/application_controller.rb
+++ b/app/controllers/knock/application_controller.rb
@@ -1,5 +1,5 @@
 module Knock
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ActionController::API
     rescue_from Knock.not_found_exception_class_name, with: :not_found
 
   private


### PR DESCRIPTION
This changes the parent of the ApplicationController from
ActionController::Base to ActionController::API.

The API class is a lighter weight alternative to the full Base class. It
is the default in rails apps in api mode.