### PR TITLE
AuthToken: test if token_lifetime is overridable

### DIFF
--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -65,6 +65,16 @@ module Knock
       end
     end
 
+    test "token_lifetime is overridable" do
+      Knock.token_lifetime = nil
+
+      custom_expiration = 30.minutes.from_now.to_i
+      token = AuthToken.new(payload: {sub: 'foo', exp: custom_expiration}).token
+      Timecop.travel(10.years.from_now) do
+        assert AuthToken.new(token: token).payload.has_key?('exp')
+      end
+    end
+
     test "validate aud when verify_options[:verify_aud] is true" do
       verify_options = {
           verify_aud: true


### PR DESCRIPTION
Hey, I just didn't know if it's possible to override `token_lifetime`, if I need it for example as email confirmation token, so I tested it, and now you have one more test in your suite :)