### PR TITLE
Stop decoding Auth0 client secrets by default

### DIFF
--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -39,7 +39,7 @@ Knock.setup do |config|
   # config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
 
   ## If using Auth0, uncomment the line below
-  # config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }
+  # config.token_secret_signature_key = -> { Rails.application.secrets.auth0_client_secret }
 
   ## Public key
   ## ----------


### PR DESCRIPTION
This pull request fixes #149.

> As of December 2016, Auth0 is not Base64-encoding the client secrets. Existing secrets on Auth0 are remaining that way, but newly generated ones won't be.
> 
> I propose changing the config/knock.rb template to not use JWT.base64url_decode, to maintain out-of-the-box functionality with new Auth0 implementations. That line is specifically written for Auth0 implementations and anyone with a Base64-encoded secret is already using it, so changing the default shouldn't affect them.