### PR TITLE
Add unauthorized_entity to authenticate_for's default for called by callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Add unauthorized_entity to authenticate_for's default for called by callback
+
 ## [2.1.1] - 2017-02-11
 ### Fixed
 - Stop trying to retrieve user from empty payload when no token is given

--- a/test/dummy/app/controllers/custom_unauthorized_entity_controller.rb
+++ b/test/dummy/app/controllers/custom_unauthorized_entity_controller.rb
@@ -7,7 +7,7 @@ class CustomUnauthorizedEntityController < ApplicationController
 
   private
 
-  def unauthorized_entity(entity)
+  def unauthorized_entity
     head :not_found
   end
 end

--- a/test/dummy/test/controllers/v1/test_namespaced_controller_test.rb
+++ b/test/dummy/test/controllers/v1/test_namespaced_controller_test.rb
@@ -3,17 +3,25 @@ require 'test_helper'
 
 module Knock
   class TestNamespacedControllerTest < ActionDispatch::IntegrationTest
-
     setup do
       @user = V1::User.first
+      @token = Knock::AuthToken.new(payload: { sub: @user.id }).token
     end
 
     test "allow namespaced models" do
-      token = Knock::AuthToken.new(payload: { sub: @user.id }).token
-      get v1_test_namespaced_index_url, headers: {'Authorization': "Bearer #{token}"}
+      get v1_test_namespaced_index_url, headers: {'Authorization': "Bearer #{@token}"}
       assert_response :ok
       assert_equal @user, @controller.current_v1_user
     end
 
+    test 'responds with unauthorized' do
+      get v1_test_namespaced_index_url
+      assert_response :unauthorized
+    end
+
+    test 'responds with unauthorized with invalid token in header' do
+      get v1_test_namespaced_index_url, headers: {'Authorization': 'Bearer invalid'}
+      assert_response :unauthorized
+    end
   end
 end


### PR DESCRIPTION
fixes #228

I'm having the same problem described in issue.
This fix make expected behaviour as the doc suggests.
