### PR TITLE
Fix knock authenticable

### DIFF
--- a/lib/generators/knock/install_generator.rb
+++ b/lib/generators/knock/install_generator.rb
@@ -1,3 +1,5 @@
+require 'rails/generators'
+
 module Knock
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path("../../templates", __FILE__)

--- a/lib/knock/engine.rb
+++ b/lib/knock/engine.rb
@@ -1,6 +1,7 @@
+require 'rails/engine'
+
 module Knock
   class Engine < ::Rails::Engine
-    paths.add 'lib', eager_load: true
     isolate_namespace Knock
   end
 end

--- a/lib/knock/engine.rb
+++ b/lib/knock/engine.rb
@@ -2,6 +2,7 @@ require 'rails/engine'
 
 module Knock
   class Engine < ::Rails::Engine
+    paths.add 'lib', eager_load: true
     isolate_namespace Knock
   end
 end

--- a/lib/knock/engine.rb
+++ b/lib/knock/engine.rb
@@ -1,6 +1,6 @@
 module Knock
   class Engine < ::Rails::Engine
-    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
+    paths.add 'lib', eager_load: true
     isolate_namespace Knock
   end
 end


### PR DESCRIPTION
Currently Knock::Authenticable does not get autoloaded when including on models. This PR reverts a previous commit that eager loads all knock lib models. 