### PR TITLE
update default token_secret_signature_key

### DIFF
--- a/lib/generators/templates/knock.rb
+++ b/lib/generators/templates/knock.rb
@@ -36,7 +36,7 @@ Knock.setup do |config|
   ## Configure the key used to sign tokens.
   ##
   ## Default:
-  # config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+  # config.token_secret_signature_key = -> { Rails.application.credentials.secret_key_base }
 
   ## If using Auth0, uncomment the line below
   # config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -11,7 +11,7 @@ module Knock
   self.token_signature_algorithm = 'HS256'
 
   mattr_accessor :token_secret_signature_key
-  self.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+  self.token_secret_signature_key = -> { Rails.application.credentials.secret_key_base }
 
   mattr_accessor :token_public_key
   self.token_public_key = nil


### PR DESCRIPTION
Updated the default token_secret_signature_key from `Rails.application.secrets.secret_key_base` to `Rails.application.credentials.secret_key_base` since it was moved to an encrypted file due to [this](https://guides.rubyonrails.org/5_2_release_notes.html#credentials) .
