### PR TITLE
Fix NoMethodError when including Knock::Tokenizable

### DIFF
--- a/lib/knock/tokenizable.rb
+++ b/lib/knock/tokenizable.rb
@@ -19,7 +19,7 @@ module Knock
     end
 
     def to_token_payload
-      { sub: @object.id }
+      { sub: id }
     end
 
     def to_token

--- a/lib/knock/tokenizable.rb
+++ b/lib/knock/tokenizable.rb
@@ -4,7 +4,7 @@ module Knock
   # for token serialization and deserialization.
   module Tokenizable
     def self.included(base)
-      base.extends ClassMethods
+      base.extend ClassMethods
     end
 
     module ClassMethods

--- a/test/dummy/app/models/admin.rb
+++ b/test/dummy/app/models/admin.rb
@@ -1,16 +1,10 @@
 class Admin < ActiveRecord::Base
+  include Knock::Tokenizable
+
   has_secure_password
 
   def self.from_token_request request
     email = request.params["auth"] && request.params["auth"]["email"]
     self.find_by email: email
-  end
-
-  def self.from_token_payload payload
-    self.find payload["sub"]
-  end
-
-  def to_token_payload
-    {sub: id}
   end
 end

--- a/test/dummy/test/models/admin_test.rb
+++ b/test/dummy/test/models/admin_test.rb
@@ -1,7 +1,33 @@
 require 'test_helper'
+require 'timecop'
 
 class AdminTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @admin = admins(:one)
+  end
+
+  test "returns payload with :sub" do
+    assert_equal @admin.to_token_payload[:sub], @admin.id
+  end
+
+  test "returns encoded JWT token" do
+    Timecop.travel(Time.current) do
+      token = Knock::AuthToken.new(payload: { sub: @admin.id }).token
+
+      assert_equal @admin.to_token, token
+    end
+  end
+
+  test "returns a Admin instance using a decoded payload" do
+    payload = Knock::AuthToken.new(payload: { "sub" => @admin.id }).payload
+
+    assert_equal Admin.from_token_payload(payload), @admin
+  end
+
+
+  test "returns a Admin instance using a token" do
+    token = @admin.to_token
+
+    assert_equal Admin.from_token(token), @admin
+  end
 end


### PR DESCRIPTION
I fixed NoMethodError when including Knock::Tokenizable.
And I removed  instance variable `@object` from Knock::Tokenizable,  because I think that  Knock expects Knock::Tokenizable to be included by descendent of ApplicationRecord  and `id` method is in the descendent, not `@object`.


```
irb(main):006:0> include Knock::Tokenizable
Traceback (most recent call last):
        3: from (irb):6
        2: from (irb):6:in `rescue in irb_binding'
        1: from (irb):6:in `include'
NoMethodError (undefined method `extends' for Object:Class)
```