### PR TITLE
Fix current entity getter name generation

### DIFF
--- a/lib/knock/authenticable.rb
+++ b/lib/knock/authenticable.rb
@@ -9,7 +9,7 @@ module Knock
   # the token payload.
   module Authenticable
     def authenticate_for(entity_class)
-      getter_name = "current_#{entity_class.to_s.parameterize.underscore}"
+      getter_name = GetterName.new(entity_class).cleared
       define_current_entity_getter(entity_class, getter_name)
       public_send(getter_name)
     end

--- a/lib/knock/authenticable/getter_name.rb
+++ b/lib/knock/authenticable/getter_name.rb
@@ -1,0 +1,15 @@
+module Knock
+  module Authenticable
+    class GetterName
+      attr_reader :entity_class
+
+      def initialize(entity_class)
+        @entity_class = entity_class
+      end
+
+      def cleared
+        "current_#{entity_class.to_s.gsub('::', '').underscore}"
+      end
+    end
+  end
+end

--- a/test/unit/knock/authenticable/getter_name_test.rb
+++ b/test/unit/knock/authenticable/getter_name_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+module Knock
+  module Authenticable
+    class GetterNameTest < ActiveSupport::TestCase
+      test "check simple model names" do
+        getter_name = GetterName.new("Test").cleared
+        assert_equal getter_name, "current_test"
+      end
+
+      test "check pascal cased names" do
+        getter_name = GetterName.new("TestModel").cleared
+        assert_equal getter_name, "current_test_model"
+      end
+
+      test "check namespaced model names" do
+        getter_name = GetterName.new("Test::Model").cleared
+        assert_equal getter_name, "current_test_model"
+      end
+
+      test "check double namespaced model names" do
+        getter_name = GetterName.new("Test::Double::Model").cleared
+        assert_equal getter_name, "current_test_double_model"
+      end
+    end
+  end
+end


### PR DESCRIPTION
In case my entity_class name contains two words without spaces (PascalCase), method 'parameterize' will replace it on two words without spaces and letters with lowercase.

Example:
> "ExternalPartner".parameterize
"externalpartner"

In this case underscore won't change the result.

That's why it would be better to change the order:
> 'ExternalPartner'.underscore.parameterize
"external_partner"

Then it will be ok