### PR TITLE
Change token_secret_signature_key default

### DIFF
--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -17,7 +17,13 @@ module Knock
 
   # Configure the key used to sign tokens.
   mattr_accessor :token_secret_signature_key
-  self.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+  self.token_secret_signature_key = -> do
+    if Rails.application.respond_to?(:secret_key_base)
+      Rails.application.secret_key_base
+    else
+      Rails.application.secrets.secret_key_base
+    end
+  end
 
   # Configure the public key used to decode tokens, when required.
   mattr_accessor :token_public_key

--- a/test/dummy/config/initializers/knock.rb
+++ b/test/dummy/config/initializers/knock.rb
@@ -1,6 +1,6 @@
 Knock.setup do |config|
   config.token_signature_algorithm = 'HS256'
-  config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+  config.token_secret_signature_key = -> { Rails.application.secret_key_base }
   config.token_public_key = nil
   config.token_audience = nil
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,7 @@ class ActiveSupport::TestCase
 
   def reset_knock_configuration
     Knock.token_signature_algorithm = 'HS256'
-    Knock.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+    Knock.token_secret_signature_key = -> { Rails.application.secret_key_base }
     Knock.token_public_key = nil
     Knock.token_audience = nil
     Knock.token_lifetime = 1.day


### PR DESCRIPTION
As of rails 5.2 there's a configuration option `Rails.application.secret_key_base` which accomodates all different ways to specify secret_key_base, i.e.

- env
- credentials
- secrets

closes https://github.com/nsarno/knock/pull/225