### PR TITLE
fixes token_lifetime with nil values issue

### DIFF
--- a/app/model/knock/auth_token.rb
+++ b/app/model/knock/auth_token.rb
@@ -65,7 +65,8 @@ module Knock
     end
 
     def verify_lifetime?
-      !Knock.token_lifetime.nil?
+      token_lifetime = Knock.token_lifetime
+      !token_lifetime.nil? && (!token_lifetime.is_a?(Hash) || !token_lifetime[entity_class_name].nil?)
     end
 
     def verify_claims

--- a/test/model/knock/auth_token_test.rb
+++ b/test/model/knock/auth_token_test.rb
@@ -157,5 +157,18 @@ module Knock
 
       assert auth_token.payload[:exp], admin_lifespan.from_now.to_i
     end
+
+    test "returns the correct payload expiration value when token_lifetime is a hash with a nil value" do
+      user_lifespan = 7.days
+      admin_lifespan = nil
+
+      Knock.token_lifetime = {
+        user: user_lifespan,
+        admin: admin_lifespan
+      }
+      auth_token = Knock::AuthToken.new(entity_class_name: :admin)
+
+      assert_not auth_token.payload.has_key?(:exp)
+    end
   end
 end


### PR DESCRIPTION
You can't have multiple entities where one of them has permanent tokens. This configuration would fail:

```
      Knock.token_lifetime = {
        user: nil,
        admin: 7.days,
      }
```

Because `token_lifetime` method assumes that if this is a hash, the values are dates/datetime:

```
def token_lifetime
      return unless verify_lifetime?

      if Knock.token_lifetime.is_a?(Hash)
        Knock.token_lifetime[entity_class_name].from_now.to_i // <---- here
      else
        Knock.token_lifetime.from_now.to_i
      end
end
```

This PR fixes the issue by updating `verify_lifetime?` method.